### PR TITLE
zoom, pan and tilt, and rotation limit test

### DIFF
--- a/Common/Code/Camera.cpp
+++ b/Common/Code/Camera.cpp
@@ -10,7 +10,7 @@
 static const float MIN_ZOOM = -10.0f;
 //we need a bound on the max. zoom because on small nodes the calculated max puts the target behind the camera.
 //this might be a bug in targeting...?
-static const float MAX_MAX_ZOOM = -0.06f;
+static const float MAX_MAX_ZOOM = -2.0f; // -0.06f;
 
 // TODO: better way to register this
 void cameraMoveFinishedCallback(void);


### PR DESCRIPTION
A start of an experiment to limit zoom, pan and tilt, and rotation. This is done mostly by keeping track of the gestures done on the View accumulatively, for pan, tilt, and rotation (zoom is limited in MAX_ZOOM in camera.cpp). Something to try to see if we like it. 

It still needs work, notably the rotation gesture needs to effect the pan and tilt stored numbers, and vice versa - ie. you can mess this up by two finger rotating, then single finger rotating. 

Currently it limits how far you can pull the globe north or south, and how far you can tilt the globe, and how far you can zoom in. Test each of these one at a time. 

When it hits a limit the view should do something, perhaps bounce slightly, to indicate limit hit. 

A better fix would be to limit the globe thru the rotation matrix, if there is time I'd like to try this.

"punch" thru node selection which causes you to be inside the globe hasn't been looked at yet. It would be nice if the globe noticed the node selected was "far away" from the camera it rotated to it first instead of zooming in. 