### PR TITLE
limiting pan and tilt, and zoom

### DIFF
--- a/Android-NDK/renderer.cpp
+++ b/Android-NDK/renderer.cpp
@@ -285,7 +285,6 @@ bool Renderer::initialize() {
 
     LOG("created GL context");
 
-    GlobeVisualization::setPortrait(_smallScreen);
     DefaultVisualization::setPortrait(_smallScreen);
 
     _mapController = new MapController;

--- a/Android-NDK/renderer.cpp
+++ b/Android-NDK/renderer.cpp
@@ -286,6 +286,7 @@ bool Renderer::initialize() {
     LOG("created GL context");
 
     GlobeVisualization::setPortrait(_smallScreen);
+    DefaultVisualization::setPortrait(_smallScreen);
 
     _mapController = new MapController;
     _mapController->display->camera->setDisplaySize(width, height);

--- a/Common/Code/Camera.cpp
+++ b/Common/Code/Camera.cpp
@@ -10,7 +10,7 @@
 static const float MIN_ZOOM = -10.0f;
 //we need a bound on the max. zoom because on small nodes the calculated max puts the target behind the camera.
 //this might be a bug in targeting...?
-static const float MAX_MAX_ZOOM = -0.06f;
+static const float MAX_MAX_ZOOM = -2.00f;
 
 // TODO: better way to register this
 void cameraMoveFinishedCallback(void);
@@ -298,7 +298,6 @@ Vector3 Camera::applyModelViewToPoint(Vector2 point) {
     return Vector3(vec4FromPoint.getX(), vec4FromPoint.getY(), vec4FromPoint.getZ());
 }
 
-
 void Camera::rotateRadiansX(float rotate) {
     
     setRotationAndRenormalize(_rotationMatrix * Matrix4::rotation(rotate, Vector3(1.0f, 0.0f, 0.0f)));
@@ -310,15 +309,7 @@ void Camera::rotateRadiansY(float rotate) {
     
     setRotationAndRenormalize(Matrix4::rotation(rotate, Vector3(1.0f, 0.0f, 0.0f)) * _rotationMatrix);
     
-    // dot product to get angle. col X compared to Y
-    /*
-    float angle = Vectormath::Aos::dot(_rotationMatrix.getCol(0).getXYZ(), Vector3(0.0f, 1.0f, 0.0f));
-    if (angle < 0.55) {
-        _rotationMatrix = old;
-    }
-     */
-    
-    if ( anglePastLimit() ) _rotationMatrix = old;
+    if (checkIfAnglePastLimit()) _rotationMatrix = old;
 }
 
 void Camera::rotateRadiansZ(float rotate) {
@@ -327,38 +318,14 @@ void Camera::rotateRadiansZ(float rotate) {
     
     setRotationAndRenormalize(_rotationMatrix = Matrix4::rotation(rotate, Vector3(0.0f, 0.0f, 1.0f)) * _rotationMatrix);
     
-    /*
-    float angle = Vectormath::Aos::dot(_rotationMatrix.getCol(0).getXYZ(), Vector3(0.0f, 1.0f, 0.0f));
-    if (angle < 0.55) {
-        _rotationMatrix = old;
-    }
-    */
-    
-    if ( anglePastLimit() ) _rotationMatrix = old;
+    if (checkIfAnglePastLimit()) _rotationMatrix = old;
 }
 
-
-void Camera::print_matrix4(const Matrix4 &mat4) {
-    std::string result = "";
-    
-    int i, j;
-    for (i = 0; i < 4; i++) {
-        result = result + std::string("|");
-        for (j=0; j < 4; j++) {
-            result = result + std::string(" ") + std::to_string(_rotationMatrix.getElem(j, i));
-        }
-        result = result + std::string("| \n");
-    }
-    
-    LOG("%s", result.c_str());
-}
-
-
-bool Camera::anglePastLimit() {
+bool Camera::checkIfAnglePastLimit() {
     
     float angle = Vectormath::Aos::dot(_rotationMatrix.getCol(0).getXYZ(), Vector3(0.0f, 1.0f, 0.0f));
     
-    if (angle < 0.55) return true;
+    if (angle < 0.55) return true; // 0.55 arbitrary value that seems to work best for tilt
     
     return false;
 }
@@ -476,5 +443,20 @@ void Camera::translateYAnimated(float translateY, TimeInterval duration) {
     _translationYTarget = translateY;
     _translationYStartTime = _updateTime;
     _translationYDuration = duration;
+}
+
+void Camera::print_matrix4(const Matrix4 &mat4) {
+    std::string result = "";
+    
+    int i, j;
+    for (i = 0; i < 4; i++) {
+        result = result + std::string("|");
+        for (j=0; j < 4; j++) {
+            result = result + std::string(" ") + std::to_string(_rotationMatrix.getElem(j, i));
+        }
+        result = result + std::string("| \n");
+    }
+    
+    LOG("%s", result.c_str());
 }
 

--- a/Common/Code/Camera.cpp
+++ b/Common/Code/Camera.cpp
@@ -21,7 +21,6 @@ void cameraResetFinishedCallback(void);
 Camera::Camera() :
 
     _mode(MODE_UNKNOWN),
-    _orientation(ORIENTATION_LANDSCAPE),
     _displayWidth(0.0f),
     _displayHeight(0.0f),
     _target(0.0f, 0.0f, 0.0f),
@@ -86,10 +85,6 @@ void Camera::update(TimeInterval currentTime) {
     _projectionMatrix = projectionMatrix;
     _modelViewMatrix = modelView;
     _modelViewProjectionMatrix = projectionMatrix * modelView;
-    
-    if(_orientation == ORIENTATION_PORTRAIT) {
-        _modelViewProjectionMatrix = _modelViewProjectionMatrix * Matrix4::rotation(M_PI_2, Vector3(0.0f, 0.0f, 1.0f));
-    }
 }
 
 void Camera::handleIdleMovement(TimeInterval delta) {
@@ -417,10 +412,6 @@ void Camera::zoomAnimated(float zoom, TimeInterval duration) {
 
 void Camera::setMode(int mode) {
     _mode = mode;
-}
-
-void Camera::setOrientation(int orientation) {
-    _orientation = orientation;
 }
 
 void Camera::setTarget(const Target& target, TimeInterval duration) {

--- a/Common/Code/Camera.cpp
+++ b/Common/Code/Camera.cpp
@@ -10,7 +10,9 @@
 static const float MIN_ZOOM = -10.0f;
 //we need a bound on the max. zoom because on small nodes the calculated max puts the target behind the camera.
 //this might be a bug in targeting...?
-static const float MAX_MAX_ZOOM = -2.00f;
+static const float MAX_MAX_ZOOM = -0.06f;
+
+static const float TILT_AND_PAN_RESTRICT_ANGLE = 0.55;
 
 // TODO: better way to register this
 void cameraMoveFinishedCallback(void);
@@ -325,7 +327,7 @@ bool Camera::checkIfAnglePastLimit() {
     
     float angle = Vectormath::Aos::dot(_rotationMatrix.getCol(0).getXYZ(), Vector3(0.0f, 1.0f, 0.0f));
     
-    if (angle < 0.55) return true; // 0.55 arbitrary value that seems to work best for tilt
+    if (angle < TILT_AND_PAN_RESTRICT_ANGLE) return true; // 0.55 arbitrary value that seems to work best for tilt
     
     return false;
 }

--- a/Common/Code/Camera.cpp
+++ b/Common/Code/Camera.cpp
@@ -351,9 +351,7 @@ void Camera::zoomByScale(float zoom) {
 void Camera::resetZoomAndRotationAnimated(bool isPortraitMode) {
     // TODO: should have better way of distributing this flag
     GlobeVisualization::setPortrait(isPortraitMode);
-    
-    LOG("resetZoomAndRotationAnimated");
-    
+
     float targetZoom;
     Matrix4 targetRotation;
     

--- a/Common/Code/Camera.cpp
+++ b/Common/Code/Camera.cpp
@@ -465,18 +465,20 @@ void Camera::translateYAnimated(float translateY, TimeInterval duration) {
     _translationYDuration = duration;
 }
 
+// Note, std::to_string is not implemented in the NDK version being used for Android. For now,
+// comment this out. Put back in to test on iOS.
 void Camera::print_matrix4(const Matrix4 &mat4) {
-    std::string result = "";
-    
-    int i, j;
-    for (i = 0; i < 4; i++) {
-        result = result + std::string("|");
-        for (j=0; j < 4; j++) {
-            result = result + std::string(" ") + std::to_string(_rotationMatrix.getElem(j, i));
-        }
-        result = result + std::string("| \n");
-    }
-    
-    LOG("%s", result.c_str());
+    LOG("Code commented out due to Android issues");
+//    std::string result = "";
+//    
+//    int i, j;
+//    for (i = 0; i < 4; i++) {
+//        result = result + std::string("|");
+//        for (j=0; j < 4; j++) {
+//            result = result + std::string(" ") + std::to_string(_rotationMatrix.getElem(j, i));
+//        }
+//        result = result + std::string("| \n");
+//    }
+//    
+//    LOG("%s", result.c_str());
 }
-

--- a/Common/Code/Camera.hpp
+++ b/Common/Code/Camera.hpp
@@ -27,7 +27,6 @@ struct Target {
 class Camera {
     
     int _mode;
-    int _orientation;
     
     float _displayWidth, _displayHeight;
     //TODO maybe target should be a Target?
@@ -96,11 +95,7 @@ public:
     static const int MODE_GLOBE = 1;
     static const int MODE_NETWORK = 2;
     
-    static const int ORIENTATION_LANDSCAPE = 0;
-    static const int ORIENTATION_PORTRAIT = 1;
-
     void setMode(int mode);
-    void setOrientation(int orientation);
     void setTarget(const Target& target, TimeInterval duration = DEFAULT_MOVE_TIME);
     Vector3 target(void) { return _target; }
     void setDisplaySize(float width, float height) { _displayWidth = width; _displayHeight = height; }

--- a/Common/Code/Camera.hpp
+++ b/Common/Code/Camera.hpp
@@ -83,7 +83,7 @@ class Camera {
     void handleAnimatedRotation(TimeInterval delta);
     void setRotationAndRenormalize(const Matrix4& matrix);
 
-    bool anglePastLimit();
+    bool checkIfAnglePastLimit();
 
 public:
     Camera();

--- a/Common/Code/Camera.hpp
+++ b/Common/Code/Camera.hpp
@@ -25,6 +25,8 @@ struct Target {
  has nice functions for targeting, animated zoom, rotation, etc.
  */
 class Camera {
+    
+    int _mode;
     float _displayWidth, _displayHeight;
     //TODO maybe target should be a Target?
     Vector3 _target;
@@ -88,6 +90,11 @@ class Camera {
 public:
     Camera();
     
+    static const int MODE_UNKNOWN = 0;
+    static const int MODE_GLOBE = 1;
+    static const int MODE_NETWORK = 2;
+
+    void setMode(int mode);
     void setTarget(const Target& target, TimeInterval duration = DEFAULT_MOVE_TIME);
     Vector3 target(void) { return _target; }
     void setDisplaySize(float width, float height) { _displayWidth = width; _displayHeight = height; }

--- a/Common/Code/Camera.hpp
+++ b/Common/Code/Camera.hpp
@@ -82,7 +82,9 @@ class Camera {
     void handleAnimatedZoom(TimeInterval delta);
     void handleAnimatedRotation(TimeInterval delta);
     void setRotationAndRenormalize(const Matrix4& matrix);
-    
+
+    bool anglePastLimit();
+
 public:
     Camera();
     
@@ -123,6 +125,9 @@ public:
     void stopMomentumRotation();
     
     void resetZoomAndRotationAnimated(bool isPortraitMode);
+    
+    
+    void print_matrix4(const Matrix4 &mat4);
 };
 
 #endif

--- a/Common/Code/Camera.hpp
+++ b/Common/Code/Camera.hpp
@@ -27,6 +27,8 @@ struct Target {
 class Camera {
     
     int _mode;
+    int _orientation;
+    
     float _displayWidth, _displayHeight;
     //TODO maybe target should be a Target?
     Vector3 _target;
@@ -93,8 +95,12 @@ public:
     static const int MODE_UNKNOWN = 0;
     static const int MODE_GLOBE = 1;
     static const int MODE_NETWORK = 2;
+    
+    static const int ORIENTATION_LANDSCAPE = 0;
+    static const int ORIENTATION_PORTRAIT = 1;
 
     void setMode(int mode);
+    void setOrientation(int orientation);
     void setTarget(const Target& target, TimeInterval duration = DEFAULT_MOVE_TIME);
     Vector3 target(void) { return _target; }
     void setDisplaySize(float width, float height) { _displayWidth = width; _displayHeight = height; }

--- a/Common/Code/DefaultVisualization.cpp
+++ b/Common/Code/DefaultVisualization.cpp
@@ -13,6 +13,12 @@
 
 bool deviceIsOld();
 
+static bool sPortrait = false;
+
+void DefaultVisualization::setPortrait(bool b) {
+    sPortrait = b;
+}
+
 void DefaultVisualization::activate(std::vector<NodePointer> nodes) {
     for(unsigned int i = 0; i < nodes.size(); i++) {
         nodes[i]->visualizationActive = true;
@@ -20,7 +26,10 @@ void DefaultVisualization::activate(std::vector<NodePointer> nodes) {
 }
 
 Point3 DefaultVisualization::nodePosition(NodePointer node) {
-    return Point3(log10f(node->importance)+2.0f, node->positionX, node->positionY);
+    // We want the long axis of the network view aligned to the long axis of the screen, so we generate the node positions differently
+    // depending on whether we are in portrait mode or not
+    return sPortrait ? Point3(node->positionX, log10f(node->importance)+2.0f, node->positionY) :
+                       Point3(log10f(node->importance)+2.0f, node->positionX, node->positionY);
 }
 
 float DefaultVisualization::nodeSize(NodePointer node) {

--- a/Common/Code/DefaultVisualization.hpp
+++ b/Common/Code/DefaultVisualization.hpp
@@ -30,6 +30,8 @@ public:
     virtual void updateDisplayForSelectedNodes(shared_ptr<MapDisplay> display, std::vector<NodePointer> nodes);
     virtual void resetDisplayForSelectedNodes(shared_ptr<MapDisplay> display, std::vector<NodePointer> nodes);
     virtual void updateLineDisplay(shared_ptr<MapDisplay> display, std::vector<ConnectionPointer>connections);
+    
+    static void setPortrait(bool);
 };
 
 #endif

--- a/Common/Code/GlobeVisualization.cpp
+++ b/Common/Code/GlobeVisualization.cpp
@@ -11,39 +11,15 @@
 #include "MapDisplay.hpp"
 #include <stdlib.h>
 
-static bool sPortrait = false;
-
 Point3 polarToCartesian(float latitude, float longitude, float radius) {
-    
     float x = radius * cos(latitude) * cos(longitude);
     float y = radius * sin(latitude);
     float z = -radius * cos(latitude) * sin(longitude);
     return Point3(x, y, z);
 }
 
-Point3 polarToCartesianCheckPortrait(float latitude, float longitude, float radius) {
-    // We want to build the globe so that the default rotation axis is between the poles, and North America is
-    // facing the camera. Need slightly different contruction for landscape and portrait mode (due to different
-    // camera rotations)
-    if(sPortrait) {
-        float x = radius * sin(latitude);
-        float y = -radius * cos(latitude) * cos(longitude);
-        float z = -radius * cos(latitude) * sin(longitude);
-        return Point3(x, y, z);
-    }
-    else {
-        return polarToCartesian(latitude, longitude, radius);
-    }
-}
-
-void GlobeVisualization::setPortrait(bool b) {
-    sPortrait = b;
-}
-
 void GlobeVisualization::activate(std::vector<NodePointer> nodes) {
     srand(81531);
-    
-    
     
     for(unsigned int i = 0; i < nodes.size(); i++) {
 #if 0
@@ -103,8 +79,8 @@ void GlobeVisualization::updateLineDisplay(shared_ptr<MapDisplay> display, std::
             Color lineColorA = Color(intensity, intensity,intensity, 1.0);
             Color lineColorB = Color(intensity, intensity, intensity, 1.0);
             
-            Point3 positionA = polarToCartesianCheckPortrait(latitude, longitude, 1.1);
-            Point3 positionB = polarToCartesianCheckPortrait(nextLatitude, longitude, 1.1);
+            Point3 positionA = polarToCartesian(latitude, longitude, 1.1);
+            Point3 positionB = polarToCartesian(nextLatitude, longitude, 1.1);
             
             lines->updateLine(currentIndex, positionA, lineColorA, positionB, lineColorB);
             currentIndex++;
@@ -125,8 +101,8 @@ void GlobeVisualization::updateLineDisplay(shared_ptr<MapDisplay> display, std::
                 lineColorA = Color(highlightIntensity, highlightIntensity, highlightIntensity, 1.0f);
                 lineColorB = Color(highlightIntensity, highlightIntensity, highlightIntensity, 1.0f);
             }
-            Point3 positionA = polarToCartesianCheckPortrait(latitude, longitude, 1.1);
-            Point3 positionB = polarToCartesianCheckPortrait(latitude, nextLongitude, 1.1);
+            Point3 positionA = polarToCartesian(latitude, longitude, 1.1);
+            Point3 positionB = polarToCartesian(latitude, nextLongitude, 1.1);
             
             lines->updateLine(currentIndex, positionA, lineColorA, positionB, lineColorB);
             currentIndex++;

--- a/Common/Code/GlobeVisualization.cpp
+++ b/Common/Code/GlobeVisualization.cpp
@@ -38,6 +38,8 @@ void GlobeVisualization::setPortrait(bool b) {
 void GlobeVisualization::activate(std::vector<NodePointer> nodes) {
     srand(81531);
     
+    
+    
     for(unsigned int i = 0; i < nodes.size(); i++) {
 #if 0
         nodes[i]->visualizationActive = true;

--- a/Common/Code/GlobeVisualization.cpp
+++ b/Common/Code/GlobeVisualization.cpp
@@ -14,6 +14,14 @@
 static bool sPortrait = false;
 
 Point3 polarToCartesian(float latitude, float longitude, float radius) {
+    
+    float x = radius * cos(latitude) * cos(longitude);
+    float y = radius * sin(latitude);
+    float z = -radius * cos(latitude) * sin(longitude);
+    return Point3(x, y, z);
+}
+
+Point3 polarToCartesianCheckPortrait(float latitude, float longitude, float radius) {
     // We want to build the globe so that the default rotation axis is between the poles, and North America is
     // facing the camera. Need slightly different contruction for landscape and portrait mode (due to different
     // camera rotations)
@@ -24,10 +32,7 @@ Point3 polarToCartesian(float latitude, float longitude, float radius) {
         return Point3(x, y, z);
     }
     else {
-        float x = radius * cos(latitude) * cos(longitude);
-        float y = radius * sin(latitude);
-        float z = -radius * cos(latitude) * sin(longitude);
-        return Point3(x, y, z);
+        return polarToCartesian(latitude, longitude, radius);
     }
 }
 
@@ -98,8 +103,8 @@ void GlobeVisualization::updateLineDisplay(shared_ptr<MapDisplay> display, std::
             Color lineColorA = Color(intensity, intensity,intensity, 1.0);
             Color lineColorB = Color(intensity, intensity, intensity, 1.0);
             
-            Point3 positionA = polarToCartesian(latitude, longitude, 1.1);
-            Point3 positionB = polarToCartesian(nextLatitude, longitude, 1.1);
+            Point3 positionA = polarToCartesianCheckPortrait(latitude, longitude, 1.1);
+            Point3 positionB = polarToCartesianCheckPortrait(nextLatitude, longitude, 1.1);
             
             lines->updateLine(currentIndex, positionA, lineColorA, positionB, lineColorB);
             currentIndex++;
@@ -120,8 +125,8 @@ void GlobeVisualization::updateLineDisplay(shared_ptr<MapDisplay> display, std::
                 lineColorA = Color(highlightIntensity, highlightIntensity, highlightIntensity, 1.0f);
                 lineColorB = Color(highlightIntensity, highlightIntensity, highlightIntensity, 1.0f);
             }
-            Point3 positionA = polarToCartesian(latitude, longitude, 1.1);
-            Point3 positionB = polarToCartesian(latitude, nextLongitude, 1.1);
+            Point3 positionA = polarToCartesianCheckPortrait(latitude, longitude, 1.1);
+            Point3 positionB = polarToCartesianCheckPortrait(latitude, nextLongitude, 1.1);
             
             lines->updateLine(currentIndex, positionA, lineColorA, positionB, lineColorB);
             currentIndex++;

--- a/Common/Code/GlobeVisualization.hpp
+++ b/Common/Code/GlobeVisualization.hpp
@@ -21,8 +21,6 @@ public:
 
     virtual std::string name(void) { return "Globe View"; }
     
-    static void setPortrait(bool);
-    
     void updateLineDisplay(shared_ptr<MapDisplay> display, std::vector<ConnectionPointer>connections);
 
 };

--- a/Common/Code/MapController.cpp
+++ b/Common/Code/MapController.cpp
@@ -45,7 +45,8 @@ MapController::MapController() :
 //    _visualizations.push_back(VisualizationPointer(new TypeVisualization("EDU", AS_EDU)));
 //    _visualizations.push_back(VisualizationPointer(new TypeVisualization("T1", AS_T1)));
     
-    data->visualization = _visualizations[0];
+    data->visualization = _visualizations[0]; // TODO can we call setVisualization here instead?
+    display->setCameraMode(Camera::MODE_GLOBE);
     
     std::string globalSettingsText;
     loadTextResource(&globalSettingsText, "globalSettings", "json");
@@ -545,6 +546,16 @@ std::vector<std::string> MapController::visualizationNames(void) {
 void MapController::setVisualization(int visualization) {
     if (visualization >= _visualizations.size()) {
         visualization = 0;
+    }
+    
+    switch (visualization) {
+        case 0:
+            display->setCameraMode(Camera::MODE_GLOBE);
+            break;
+            
+        default:
+            display->setCameraMode(Camera::MODE_NETWORK);
+            break;
     }
 
     data->visualization = _visualizations[visualization];

--- a/Common/Code/MapController.cpp
+++ b/Common/Code/MapController.cpp
@@ -367,6 +367,8 @@ void MapController::highlightRoute(std::vector<NodePointer> nodeList) {
 }
 
 int MapController::indexForNodeAtPoint(Vector2 pointInView) {
+    
+
     //get point in view and adjust it for viewport
     float xOld = pointInView.x;
     float xLoOld = 0;

--- a/Common/Code/MapController.cpp
+++ b/Common/Code/MapController.cpp
@@ -46,7 +46,7 @@ MapController::MapController() :
 //    _visualizations.push_back(VisualizationPointer(new TypeVisualization("T1", AS_T1)));
     
     data->visualization = _visualizations[0]; // TODO can we call setVisualization here instead?
-    display->setCameraMode(Camera::MODE_GLOBE);
+    display->camera->setMode(Camera::MODE_GLOBE);
     
     std::string globalSettingsText;
     loadTextResource(&globalSettingsText, "globalSettings", "json");
@@ -550,11 +550,11 @@ void MapController::setVisualization(int visualization) {
     
     switch (visualization) {
         case 0:
-            display->setCameraMode(Camera::MODE_GLOBE);
+            display->camera->setMode(Camera::MODE_GLOBE);
             break;
             
         default:
-            display->setCameraMode(Camera::MODE_NETWORK);
+            display->camera->setMode(Camera::MODE_NETWORK);
             break;
     }
 

--- a/Common/Code/MapDisplay.cpp
+++ b/Common/Code/MapDisplay.cpp
@@ -168,3 +168,6 @@ void MapDisplay::startBlend(TimeInterval blend) {
     _pendingBlendTime = blend;
 }
 
+void MapDisplay::setCameraMode(int mode) {
+    camera->setMode(mode);
+}

--- a/Common/Code/MapDisplay.cpp
+++ b/Common/Code/MapDisplay.cpp
@@ -168,6 +168,10 @@ void MapDisplay::startBlend(TimeInterval blend) {
     _pendingBlendTime = blend;
 }
 
-void MapDisplay::setCameraMode(int mode) {
-    camera->setMode(mode);
-}
+//void MapDisplay::setCameraMode(int mode) {
+//    camera->setMode(mode);
+//}
+//
+//void MapDisplay::setCameraOrientation(int orientation) {
+//    camera->setOrientation(orientation);
+//}

--- a/Common/Code/MapDisplay.hpp
+++ b/Common/Code/MapDisplay.hpp
@@ -47,7 +47,8 @@ public:
     void draw(void);
     
     void startBlend(TimeInterval blend);
-    void setCameraMode(int mode);
+//    void setCameraMode(int mode);
+//    void setCameraOrientation(int orientation);
 };
 
 #endif

--- a/Common/Code/MapDisplay.hpp
+++ b/Common/Code/MapDisplay.hpp
@@ -47,6 +47,7 @@ public:
     void draw(void);
     
     void startBlend(TimeInterval blend);
+    void setCameraMode(int mode);
 };
 
 #endif

--- a/iOS/MapControllerWrapper.mm
+++ b/iOS/MapControllerWrapper.mm
@@ -66,9 +66,10 @@ Matrix4 Matrix4FromGLKMatrix4(GLKMatrix4 mat) {
         _controller = new MapController();
 
         if(![HelperMethods deviceIsiPad]) {
+            _controller->display->camera->setOrientation(Camera::ORIENTATION_PORTRAIT);
             // On phone we want a slightly different starting camera rotation/orientation
             // so the long axis is aligned vertically
-            _controller->display->camera->rotateRadiansZ(M_PI_2);
+            //_controller->display->camera->rotateRadiansZ(M_PI_2);
             _controller->display->camera->zoomByScale(-0.5);
         }
         _controller->display->setDisplayScale([[UIScreen mainScreen] scale]);

--- a/iOS/MapControllerWrapper.mm
+++ b/iOS/MapControllerWrapper.mm
@@ -61,17 +61,14 @@ Matrix4 Matrix4FromGLKMatrix4(GLKMatrix4 mat) {
 
 - (id)init {
     if (self = [super init]) {
-        GlobeVisualization::setPortrait(![HelperMethods deviceIsiPad]);
+        DefaultVisualization::setPortrait(![HelperMethods deviceIsiPad]);
         
         _controller = new MapController();
 
         if(![HelperMethods deviceIsiPad]) {
-            _controller->display->camera->setOrientation(Camera::ORIENTATION_PORTRAIT);
-            // On phone we want a slightly different starting camera rotation/orientation
-            // so the long axis is aligned vertically
-            //_controller->display->camera->rotateRadiansZ(M_PI_2);
             _controller->display->camera->zoomByScale(-0.5);
         }
+        
         _controller->display->setDisplayScale([[UIScreen mainScreen] scale]);
         _controller->updateDisplay(false);
         

--- a/iOS/ViewController.m
+++ b/iOS/ViewController.m
@@ -374,6 +374,7 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
 
 -(void)handlePan:(UIPanGestureRecognizer *)gestureRecognizer
 {
+    
     [self.controller resetIdleTimer];
     if (!self.isHandlingLongPress) {
         if ([gestureRecognizer state] == UIGestureRecognizerStateBegan) {
@@ -426,6 +427,7 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
 
 -(void)handlePinch:(UIPinchGestureRecognizer *)gestureRecognizer
 {
+    
     [self.controller resetIdleTimer];
 
     if (!self.isHandlingLongPress) {
@@ -634,6 +636,12 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
 }
 
 -(IBAction)infoButtonPressed:(id)sender {
+    
+    // [self.controller translateYAnimated:0.5f duration:3];
+    
+    [self.controller resetZoomAndRotationAnimatedForOrientation:NO];
+    
+    return;
 
     self.helpPopView.hidden = YES;
     

--- a/iOS/ViewController.m
+++ b/iOS/ViewController.m
@@ -642,12 +642,8 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
 
 -(IBAction)infoButtonPressed:(id)sender {
     
-    // [self.controller translateYAnimated:0.5f duration:3];
+    [self.controller resetZoomAndRotationAnimatedForOrientation:YES];
     
-    [self.controller resetZoomAndRotationAnimatedForOrientation:NO];
-    
-    return;
-
     self.helpPopView.hidden = YES;
     
     if (self.timelineButton.selected) {

--- a/iOS/ViewController.m
+++ b/iOS/ViewController.m
@@ -985,6 +985,7 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
     self.tracerouteASNs = [NSMutableDictionary new];
     
     //zoom out and rotate camera to default orientation on app startup
+    // TODO Why is this using GLKMatrix4MakeRotation, and not calling the methods in MapWrapper?
     GLKMatrix4 zRotation = GLKMatrix4Identity;
     float zoom = -3;
     if (![HelperMethods deviceIsiPad]) {

--- a/iOS/ViewController.m
+++ b/iOS/ViewController.m
@@ -359,6 +359,11 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
                     self.nodeTooltipPopover = [[WEPopoverController alloc] initWithContentViewController:self.nodeTooltipViewController];
                     self.nodeTooltipPopover.passthroughViews = @[self.view];
                     CGPoint center = [self.controller getCoordinatesForNodeAtIndex:i];
+                    
+                    
+                    NSLog (@"NODE SELECTED X %f", center.x);
+                    NSLog (@"NODE SELECTED Y %f", center.y);
+                    
                     [self.nodeTooltipPopover presentPopoverFromRect:CGRectMake(center.x, center.y, 1, 1) inView:self.view permittedArrowDirections:UIPopoverArrowDirectionDown animated:NO];
                     [self.controller hoverNode:i];
                 }


### PR DESCRIPTION
Limiting 2 finger rotation side to side, and tilt forth and back, so user will be less confused with state of globe. 

Limited zoom so user can not go "into" the globe. user can still select a node not facing the user and end up inside the node.

fixes #396 
fixes #394 