### PR TITLE
Fix position of popover and timeline position on iPad

### DIFF
--- a/iOS/FirstUseViewController~ipad.xib
+++ b/iOS/FirstUseViewController~ipad.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.iPad.XIB" version="3.0" toolsVersion="12120" systemVersion="16F73" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.iPad.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="ipad9_7" orientation="landscape">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -27,8 +27,8 @@
                     <rect key="frame" x="0.0" y="0.0" width="1024" height="768"/>
                     <color key="backgroundColor" red="0.16862745098039217" green="0.16862745098039217" blue="0.16078431372549018" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 </imageView>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Map of the Internet" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="k8N-mb-lpY">
-                    <rect key="frame" x="257" y="112" width="522" height="54"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Map of the Internet" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="k8N-mb-lpY">
+                    <rect key="frame" x="251" y="112" width="522" height="54"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="54" id="Zk3-KD-EKc"/>
                         <constraint firstAttribute="width" constant="522" id="igq-iz-kf2"/>
@@ -37,8 +37,8 @@
                     <color key="textColor" red="0.0" green="0.6588235294" blue="0.91372549020000005" alpha="1" colorSpace="calibratedRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="brought to you by" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tzw-br-Azw">
-                    <rect key="frame" x="422" y="239" width="193" height="21"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="brought to you by" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tzw-br-Azw">
+                    <rect key="frame" x="415.5" y="239" width="193" height="21"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="193" id="ghR-Vt-7JM"/>
                         <constraint firstAttribute="height" constant="21" id="tnJ-xZ-9YG"/>
@@ -47,15 +47,15 @@
                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" image="load_logo.png" translatesAutoresizingMaskIntoConstraints="NO" id="5yZ-3F-Hqw">
-                    <rect key="frame" x="448" y="263" width="141" height="55"/>
+                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="load_logo.png" translatesAutoresizingMaskIntoConstraints="NO" id="5yZ-3F-Hqw">
+                    <rect key="frame" x="441.5" y="263" width="141" height="55"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="141" id="1SZ-TW-d1U"/>
                         <constraint firstAttribute="height" constant="55" id="XF5-QI-VaF"/>
                     </constraints>
                 </imageView>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ASl-lL-McX">
-                    <rect key="frame" x="318" y="361" width="422" height="170"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ASl-lL-McX">
+                    <rect key="frame" x="301" y="361" width="422" height="170"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="170" id="Y1H-2P-RhT"/>
                         <constraint firstAttribute="width" constant="422" id="uhN-qK-VI4"/>
@@ -65,8 +65,8 @@
                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="U8s-3U-CHj">
-                    <rect key="frame" x="432" y="638" width="194" height="58"/>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="U8s-3U-CHj">
+                    <rect key="frame" x="415" y="638" width="194" height="58"/>
                     <color key="backgroundColor" red="0.0" green="0.6588235294" blue="0.91372549020000005" alpha="1" colorSpace="calibratedRGB"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="194" id="EbY-WO-efQ"/>
@@ -95,13 +95,12 @@
                 <constraint firstItem="ASl-lL-McX" firstAttribute="centerY" secondItem="18" secondAttribute="centerY" constant="62" id="NBg-aI-qHC"/>
                 <constraint firstItem="ASl-lL-McX" firstAttribute="centerX" secondItem="U8s-3U-CHj" secondAttribute="centerX" id="Qrm-Hn-kAg"/>
                 <constraint firstItem="18" firstAttribute="leading" secondItem="2" secondAttribute="leading" id="Spy-w1-86p"/>
-                <constraint firstItem="k8N-mb-lpY" firstAttribute="leading" secondItem="2" secondAttribute="leading" constant="256" id="Wor-6G-DRJ"/>
+                <constraint firstItem="5yZ-3F-Hqw" firstAttribute="centerX" secondItem="18" secondAttribute="centerX" id="Zeh-di-gmC"/>
                 <constraint firstItem="Tzw-br-Azw" firstAttribute="top" secondItem="k8N-mb-lpY" secondAttribute="bottom" constant="73" id="cJy-wm-ekf"/>
                 <constraint firstAttribute="trailing" secondItem="18" secondAttribute="trailing" id="feN-LY-gKx"/>
-                <constraint firstItem="ASl-lL-McX" firstAttribute="leading" secondItem="2" secondAttribute="leading" constant="317" id="jue-ni-RDq"/>
                 <constraint firstItem="5yZ-3F-Hqw" firstAttribute="centerY" secondItem="18" secondAttribute="centerY" constant="-93.5" id="mSe-wx-hkc"/>
                 <constraint firstAttribute="bottom" secondItem="18" secondAttribute="bottom" id="n1d-VZ-Z6a"/>
-                <constraint firstItem="k8N-mb-lpY" firstAttribute="centerY" secondItem="18" secondAttribute="centerY" constant="-245" id="sdQ-Bb-Byh"/>
+                <constraint firstItem="ASl-lL-McX" firstAttribute="centerX" secondItem="18" secondAttribute="centerX" id="qSu-av-od6"/>
             </constraints>
         </view>
     </objects>

--- a/iOS/LaunchScreen~ipad.storyboard
+++ b/iOS/LaunchScreen~ipad.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
     <device id="ipad12_9" orientation="landscape">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -27,26 +27,15 @@
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="load_logo.png" translatesAutoresizingMaskIntoConstraints="NO" id="nRX-mA-c0z">
                                 <rect key="frame" x="613" y="907" width="141" height="45"/>
                             </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="loading ..." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qbS-nU-zKV">
-                                <rect key="frame" x="583" y="479" width="200" height="36"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="200" id="iGl-Dd-Dw9"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
-                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                         </subviews>
                         <color key="backgroundColor" red="0.17254901960784313" green="0.16470588235294117" blue="0.16078431372549018" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
-                            <constraint firstItem="qbS-nU-zKV" firstAttribute="centerX" secondItem="nRX-mA-c0z" secondAttribute="centerX" id="ERt-yk-LE0"/>
                             <constraint firstItem="xb3-aO-Qok" firstAttribute="top" secondItem="nRX-mA-c0z" secondAttribute="bottom" constant="72" id="HwX-rZ-jxe"/>
                             <constraint firstItem="I0O-0d-cYe" firstAttribute="bottom" secondItem="xb3-aO-Qok" secondAttribute="top" id="Xcq-MN-2bP"/>
-                            <constraint firstItem="qbS-nU-zKV" firstAttribute="top" secondItem="Llm-lL-Icb" secondAttribute="bottom" constant="459" id="fOO-fw-06I"/>
+                            <constraint firstItem="nRX-mA-c0z" firstAttribute="centerX" secondItem="I0O-0d-cYe" secondAttribute="centerX" id="hB4-Od-k03"/>
                             <constraint firstAttribute="trailing" secondItem="I0O-0d-cYe" secondAttribute="trailing" id="j6i-kL-tev"/>
                             <constraint firstItem="I0O-0d-cYe" firstAttribute="leading" secondItem="Ze5-6b-2t3" secondAttribute="leading" id="rUx-01-deR"/>
                             <constraint firstItem="I0O-0d-cYe" firstAttribute="top" secondItem="Ze5-6b-2t3" secondAttribute="top" id="rZn-HD-Ug2"/>
-                            <constraint firstItem="I0O-0d-cYe" firstAttribute="centerX" secondItem="qbS-nU-zKV" secondAttribute="centerX" id="uGi-nB-DSn"/>
                         </constraints>
                     </view>
                 </viewController>

--- a/iOS/LaunchScreen~iphone.storyboard
+++ b/iOS/LaunchScreen~iphone.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -31,12 +31,6 @@
                                     <constraint firstAttribute="width" constant="141" id="ghd-Zm-aPF"/>
                                 </constraints>
                             </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="loading ..." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="THJ-ik-5yP">
-                                <rect key="frame" x="150" y="323.5" width="75" height="20.5"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="calibratedRGB"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                         </subviews>
                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
@@ -45,12 +39,10 @@
                             <constraint firstItem="PD6-W0-T9h" firstAttribute="leading" secondItem="Ze5-6b-2t3" secondAttribute="leading" id="dLY-9W-29L"/>
                             <constraint firstAttribute="trailing" secondItem="PD6-W0-T9h" secondAttribute="trailing" id="ftf-Rr-QPl"/>
                             <constraint firstItem="PD6-W0-T9h" firstAttribute="leading" secondItem="Ze5-6b-2t3" secondAttribute="leading" id="gjt-Vz-hpE"/>
-                            <constraint firstItem="THJ-ik-5yP" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="gtV-Dj-bhr"/>
                             <constraint firstItem="xb3-aO-Qok" firstAttribute="top" secondItem="PD6-W0-T9h" secondAttribute="bottom" id="mPa-oR-APH"/>
                             <constraint firstItem="PD6-W0-T9h" firstAttribute="top" secondItem="Ze5-6b-2t3" secondAttribute="top" id="uLt-8c-dlh"/>
                             <constraint firstItem="kVf-oJ-iEo" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="wZr-pK-HCK"/>
                             <constraint firstItem="xb3-aO-Qok" firstAttribute="top" secondItem="kVf-oJ-iEo" secondAttribute="bottom" constant="39" id="xM3-wu-0Sf"/>
-                            <constraint firstItem="THJ-ik-5yP" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="xgH-CV-cl8"/>
                         </constraints>
                     </view>
                 </viewController>

--- a/iOS/ViewController.m
+++ b/iOS/ViewController.m
@@ -187,7 +187,10 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
     self.errorInfoView = [[ErrorInfoView alloc] initWithFrame:CGRectMake(10, 70, 300, 40)];
     [self.view addSubview:self.errorInfoView];
     
-    
+    // logo position
+    if ([HelperMethods deviceIsiPad]) {
+        self.logo.frame = CGRectMake([[UIScreen mainScreen] bounds].size.width-self.logo.frame.size.width-10, 34, self.logo.frame.size.width, self.logo.frame.size.height);
+    }
     
     //customize timeline slider
     if ([HelperMethods deviceIsiPad]) {

--- a/iOS/ViewController.m
+++ b/iOS/ViewController.m
@@ -188,7 +188,16 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
     [self.view addSubview:self.errorInfoView];
     
     
+    
     //customize timeline slider
+    if ([HelperMethods deviceIsiPad]) {
+        CGFloat xPos = ([[UIScreen mainScreen] bounds].size.width - self.timelineSlider.frame.size.width)/2;
+        CGFloat yPos = [[UIScreen mainScreen] bounds].size.height - 80;
+        CGRect timelinePosition = CGRectMake(xPos, yPos, self.timelineSlider.frame.size.width, self.timelineSlider.frame.size.height);
+        self.timelineSlider.frame = timelinePosition;
+    }
+    
+    
     float cap = 12;
     UIImage* trackImage = [[UIImage imageNamed:@"timeline-track"] resizableImageWithCapInsets:UIEdgeInsetsMake(0, cap, 0, cap)];
     [self.timelineSlider setMinimumTrackImage:trackImage forState:UIControlStateNormal];
@@ -780,6 +789,7 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
         
         self.nodeInformationPopover.passthroughViews = @[self.view];
         CGPoint center = [self.controller getCoordinatesForNodeAtIndex:self.controller.targetNode];
+        
         [self.nodeInformationPopover presentPopoverFromRect:CGRectMake(center.x, center.y, 1, 1) inView:self.view permittedArrowDirections:UIPopoverArrowDirectionDown animated:NO];
     }
     else {
@@ -969,8 +979,8 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
     
     if (![HelperMethods deviceIsiPad]) {
         displayRect = CGRectMake(160, self.controller.displaySize.height-self.nodeInformationViewController.preferredContentSize.height, 1, 1);
-    }else {
-        displayRect = CGRectMake(512.0f, 384.0f, 1, 1);
+    } else {                
+        displayRect = CGRectMake([[UIScreen mainScreen] bounds].size.width/2, [[UIScreen mainScreen] bounds].size.height/2, 1, 1);
     }
         
     return displayRect;

--- a/iOS/en.lproj/ViewController_iPad.xib
+++ b/iOS/en.lproj/ViewController_iPad.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.iPad.XIB" version="3.0" toolsVersion="12120" systemVersion="16F73" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.iPad.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" colorMatched="YES">
     <device id="ipad9_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -170,7 +170,7 @@
         </view>
     </objects>
     <resources>
-        <image name="callout_left.png" width="195" height="54"/>
+        <image name="callout_left.png" width="170" height="54"/>
         <image name="info-selected.png" width="48" height="48"/>
         <image name="info.png" width="48" height="48"/>
         <image name="peer1-logo.png" width="111" height="35"/>


### PR DESCRIPTION
Fixed position of node popover and timeline position on iPad 12.9. Both were hard coded previously.

Remove loading from launch screens

Fixes #445 


