### PR TITLE
Fixed Globe "upsidedown" issue #448

### DIFF
--- a/Common/Code/Camera.cpp
+++ b/Common/Code/Camera.cpp
@@ -392,7 +392,7 @@ void Camera::resetZoomAndRotationAnimated(bool isPortraitMode) {
     // TODO could base rotation and translation duration off their change in value, however, for now lock it
     // to the zoom animation change (with a minimum fastestDuration to make sure those animations will run).
     TimeInterval rotationDuration = (duration < fastestDuration) ? fastestDuration : duration;
-    TimeInterval tranlationDuration = (duration < fastestDuration ) ? fastestDuration : duration;
+    TimeInterval translationDuration = (duration < fastestDuration ) ? fastestDuration : duration;
     
     //zoom via setTarget so that we also reset translation.
     Target target;
@@ -400,7 +400,7 @@ void Camera::resetZoomAndRotationAnimated(bool isPortraitMode) {
     target.maxZoom = MAX_MAX_ZOOM;
     setTarget(target, duration);
     rotateAnimated(targetRotation, rotationDuration);
-    translateYAnimated(0.0f, tranlationDuration);
+    translateYAnimated(0.0f, translationDuration);
 }
 
 void Camera::zoomAnimated(float zoom, TimeInterval duration) {

--- a/Common/Code/Camera.cpp
+++ b/Common/Code/Camera.cpp
@@ -385,14 +385,22 @@ void Camera::resetZoomAndRotationAnimated(bool isPortraitMode) {
     
     // Always perform the zoom, this will reset the center target if it has been changed elsewhere.
     //LOG("zooming from %f to %f", _zoom, targetZoom);
+    
+    TimeInterval fastestDuration = 0.25f;
     TimeInterval duration = fabs(zoomDistance) / 2;
+    
+    // TODO could base rotation and translation duration off their change in value, however, for now lock it
+    // to the zoom animation change (with a minimum fastestDuration to make sure those animations will run).
+    TimeInterval rotationDuration = (duration < fastestDuration) ? fastestDuration : duration;
+    TimeInterval tranlationDuration = (duration < fastestDuration ) ? fastestDuration : duration;
+    
     //zoom via setTarget so that we also reset translation.
     Target target;
     target.zoom = targetZoom;
     target.maxZoom = MAX_MAX_ZOOM;
     setTarget(target, duration);
-    rotateAnimated(targetRotation, duration);
-    translateYAnimated(0.0f, duration);
+    rotateAnimated(targetRotation, rotationDuration);
+    translateYAnimated(0.0f, tranlationDuration);
 }
 
 void Camera::zoomAnimated(float zoom, TimeInterval duration) {


### PR DESCRIPTION
https://github.com/steamclock/internetmap/issues/448

@nbrooke I am pretty sure this won't cause any unwanted side effects, but please have a quick look.

**Fix:** 
* Was causing the Globe to get into an "upside down" state
* Problem was due to the fact that having no change in zoom level, was setting the animation duration of the reset to 0 (which meant the reset animation would not run).
* Check for 0 duration and set a minimum duration time for rotation and translation in the resetZoomAndRotationAnimated method
* Should fix for both Android and iOS