### PR TITLE
Updated About menu (Android)

### DIFF
--- a/Android/app/src/main/java/com/peer1/internetmap/AboutPopup.java
+++ b/Android/app/src/main/java/com/peer1/internetmap/AboutPopup.java
@@ -2,6 +2,7 @@ package com.peer1.internetmap;
 
 import android.content.Intent;
 import android.graphics.Color;
+import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
 import android.view.MenuItem;
@@ -27,12 +28,12 @@ public class AboutPopup extends BaseActivity {
         getActionBar().setDisplayHomeAsUpEnabled(true);
 
         bottomButton = (Button)findViewById(R.id.bottom_button);
-        bottomButton.setText(getString(R.string.infoContactLink));
+        bottomButton.setText(getString(R.string.infoMoreAboutLink));
         bottomButton.setVisibility(View.VISIBLE);
         bottomButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                showContact();
+                showCogecoUrl();
             }
         });
 
@@ -57,8 +58,16 @@ public class AboutPopup extends BaseActivity {
         return super.onOptionsItemSelected(item);
     }
 
-    private void showContact() {
-        Intent intent = new Intent(AboutPopup.this, ContactPopup.class);
-        startActivity(intent);
+    // Until we can fix loading feedback, we are not going to load this content in an embedded WebView
+//    private void showCogecoWebView() {
+//        Intent intent = new Intent(AboutPopup.this, WebViewPopup.class);
+//        intent.putExtra(WebViewPopup.EXTRA_LOAD_URL, "https://cogecopeer1.com");
+//        intent.putExtra(WebViewPopup.EXTRA_TITLE, getString(R.string.infoMoreAboutLink));
+//        startActivity(intent);
+//    }
+
+    private void showCogecoUrl() {
+        Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://cogecopeer1.com"));
+        startActivity(browserIntent);
     }
 }

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="infoHelp">Introduction</string>
     <string name="infoContactLink">Contact Cogeco Peer 1</string>
     <string name="infoAboutLink">About Cogeco Peer 1</string>
+    <string name="infoMoreAboutLink">More About Cogeco Peer 1</string>
     <string name="infoOpenSource">Open Source</string>
     <string name="infoCredits">Credits</string>
     <string name="loading">Loading %s...</string>

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -18,7 +18,7 @@
     <string name="infoHelp">Introduction</string>
     <string name="infoContactLink">Contact Cogeco Peer 1</string>
     <string name="infoAboutLink">About Cogeco Peer 1</string>
-    <string name="infoMoreAboutLink">More About Cogeco Peer 1</string>
+    <string name="infoMoreAboutLink">Visit cogecopeer1.com</string>
     <string name="infoOpenSource">Open Source</string>
     <string name="infoCredits">Credits</string>
     <string name="loading">Loading %s...</string>


### PR DESCRIPTION
Updated About menu to link to Cogeco web page instead of contact form #469

* About page now links to Cogeco web page
* Changed button to "More About Cogeco Peer 1"

@jotkali @apike Please review.

As mentioned in the original git issue: 
> cogecopeer1.com does not load quickly on a mobile device. I have been attempting to move to an embedded WebView (instead of launching an external browser), however by doing this we lose the loading bar at the top of the native browser. Because the url takes so long to load, the user cannot tell that the page is actually loading during this time - the app seems unresponsive. I attempted to add a loading spinner to give feedback to the user, however, there is still a number of seconds after the page is finished loading (I believe while the HTML is being rendered) that the app will appear unresponsive.
> 
> Due to this I am keeping the method of loading the urls in an external browser since the UX is worse moving to an embedded WebView.