### PR TITLE
Arc highlights

### DIFF
--- a/Common/Code/DefaultVisualization.cpp
+++ b/Common/Code/DefaultVisualization.cpp
@@ -124,7 +124,7 @@ void DefaultVisualization::resetDisplayForSelectedNodes(shared_ptr<MapDisplay> d
 
 
 
-void DefaultVisualization::updateHighlightRouteLines(std::shared_ptr<MapDisplay> display, std::vector<NodePointer> nodeList) {
+void DefaultVisualization::updateHighlightRouteLines(shared_ptr<MapDisplay> display, std::vector<NodePointer> nodeList) {
     shared_ptr<DisplayLines> lines(new DisplayLines(static_cast<int>(nodeList.size() - 1)));
     lines->beginUpdate();
     Color lineColor = ColorFromRGB(0xffa300);

--- a/Common/Code/DefaultVisualization.cpp
+++ b/Common/Code/DefaultVisualization.cpp
@@ -174,3 +174,22 @@ void DefaultVisualization::resetDisplayForSelectedNodes(shared_ptr<MapDisplay> d
     
     updateDisplayForSelectedNodes(display, nodes);
 }
+
+
+
+void DefaultVisualization::updateHighlightRouteLines(std::shared_ptr<MapDisplay> display, std::vector<NodePointer> nodeList) {
+    shared_ptr<DisplayLines> lines(new DisplayLines(static_cast<int>(nodeList.size() - 1)));
+    lines->beginUpdate();
+    Color lineColor = ColorFromRGB(0xffa300);
+
+    for(unsigned int i = 0; i < nodeList.size() - 1; i++) {
+        NodePointer a = nodeList[i];
+        NodePointer b = nodeList[i+1];
+        lines->updateLine(i, nodePosition(a), lineColor, nodePosition(b), lineColor);
+    }
+
+    lines->endUpdate();
+    lines->setWidth(5.0);
+
+    display->highlightLines = lines;
+}

--- a/Common/Code/DefaultVisualization.cpp
+++ b/Common/Code/DefaultVisualization.cpp
@@ -93,65 +93,12 @@ void DefaultVisualization::updateDisplayForNodes(shared_ptr<DisplayNodes> displa
     display->endUpdate();
 }
 
-void DefaultVisualization::updateLineDisplay(shared_ptr<MapDisplay> display, std::vector<ConnectionPointer>connections) {
-    // Disabling default lines entirely for now, but leaving th code in case we want to renable it (in some cases) later
+void DefaultVisualization::updateLineDisplay(shared_ptr<MapDisplay> display) {
+    // No visualization lines for default visualization
     display->visualizationLines = shared_ptr<DisplayLines>();
     return;
-    
-//    if (deviceIsOld()) {
-//        display->visualizationLines = shared_ptr<DisplayLines>();
-//        return;
-//    }
-//    
-//    std::vector<ConnectionPointer> filteredConnections;
-//    
-//    // We are only drawing lines to nodes with > 0.01 importance, filter those out
-//    for (unsigned int i = 0; i < connections.size(); i++) {
-//        ConnectionPointer connection = connections[i];
-//        if ((connection->first->importance > 0.01) && (connection->second->importance > 0.01)) {
-//            filteredConnections.push_back(connection);
-//        }
-//    }
-//    
-//    int skipLines = 10;
-//    
-//    shared_ptr<DisplayLines> lines(new DisplayLines(filteredConnections.size() / skipLines));
-//    
-//    lines->beginUpdate();
-//    
-//    int currentIndex = 0;
-//    int count = 0;
-//    for(unsigned int i = 0; i < filteredConnections.size(); i++) {
-//        ConnectionPointer connection = filteredConnections[i];
-//        count++;
-//        
-//        if((count % skipLines) != 0) {
-//            continue;
-//        }
-//        
-//        NodePointer a = connection->first;
-//        NodePointer b = connection->second;
-//        
-//        float lineImportanceA = std::max(a->importance - 0.01f, 0.0f) * 1.5f;
-//        Color lineColorA = Color(lineImportanceA, lineImportanceA, lineImportanceA, 1.0);
-//        
-//        float lineImportanceB = std::max(b->importance - 0.01f, 0.0f) * 1.5f;
-//        Color lineColorB = Color(lineImportanceB, lineImportanceB, lineImportanceB, 1.0);
-//        
-//        Point3 positionA = nodePosition(a);
-//        Point3 positionB = nodePosition(b);
-//        
-//        Point3 outsideA = MapUtilities().pointOnSurfaceOfNode(nodeSize(a), positionA, positionB);
-//        Point3 outsideB = MapUtilities().pointOnSurfaceOfNode(nodeSize(b), positionB, positionA);
-//        
-//        lines->updateLine(currentIndex, outsideA, lineColorA, outsideB, lineColorB);
-//        currentIndex++;
-//    }
-//    
-//    lines->endUpdate();;
-//    
-//    display->visualizationLines = lines;
 }
+
 
 
 void DefaultVisualization::updateDisplayForSelectedNodes(shared_ptr<MapDisplay> display, std::vector<NodePointer> nodes) {
@@ -191,5 +138,38 @@ void DefaultVisualization::updateHighlightRouteLines(std::shared_ptr<MapDisplay>
     lines->endUpdate();
     lines->setWidth(5.0);
 
+    display->highlightLines = lines;
+}
+
+void DefaultVisualization::updateConnectionLines(shared_ptr<MapDisplay> display, NodePointer node, std::vector<ConnectionPointer> connections) {
+    shared_ptr<DisplayLines> lines(new DisplayLines(connections.size()));
+    lines->beginUpdate();
+
+    Color otherColor = ColorFromRGB(SELECTED_CONNECTION_COLOR_OTHER_HEX);
+    Color selfColor = ColorFromRGB(SELECTED_CONNECTION_COLOR_SELF_HEX);
+
+    for(unsigned int i = 0; i < connections.size(); i++) {
+        ConnectionPointer connection = connections[i];
+        NodePointer a = connection->first;
+        NodePointer b = connection->second;
+
+        // Draw lines from outside of nodes instead of center
+        Point3 positionA = nodePosition(a);
+        Point3 positionB = nodePosition(b);
+
+        Point3 outsideA = MapUtilities().pointOnSurfaceOfNode(nodeSize(a), positionA, positionB);
+        Point3 outsideB = MapUtilities().pointOnSurfaceOfNode(nodeSize(b), positionB, positionA);
+
+        // The bright side is the current node
+        if(node == a) {
+            lines->updateLine(i, outsideA, selfColor, outsideB, otherColor);
+        }
+        else {
+            lines->updateLine(i, outsideA, otherColor, outsideB, selfColor);
+        }
+    }
+
+    lines->endUpdate();
+    lines->setWidth(((connections.size() < 20) ? 2 : 1));
     display->highlightLines = lines;
 }

--- a/Common/Code/DefaultVisualization.hpp
+++ b/Common/Code/DefaultVisualization.hpp
@@ -10,7 +10,7 @@
 
 //TODO: move these to a better place
 #define SELECTED_NODE_COLOR_HEX 0x00A8EC
-#define SELECTED_CONNECTION_COLOR_SELF_HEX 0x7F7F7F
+#define SELECTED_CONNECTION_COLOR_SELF_HEX 0x383838
 #define SELECTED_CONNECTION_COLOR_OTHER_HEX 0xE0E0E0
 
 //#define UIColorFromRGB(rgbValue) [UIColor colorWithRed:((float)((rgbValue & 0xFF0000) >> 16))/255.0 green:((float)((rgbValue & 0xFF00) >> 8))/255.0 blue:((float)(rgbValue & 0xFF))/255.0 alpha:1.0]

--- a/Common/Code/DefaultVisualization.hpp
+++ b/Common/Code/DefaultVisualization.hpp
@@ -30,6 +30,8 @@ public:
     virtual void updateDisplayForSelectedNodes(shared_ptr<MapDisplay> display, std::vector<NodePointer> nodes);
     virtual void resetDisplayForSelectedNodes(shared_ptr<MapDisplay> display, std::vector<NodePointer> nodes);
     virtual void updateLineDisplay(shared_ptr<MapDisplay> display, std::vector<ConnectionPointer>connections);
+    virtual void updateHighlightRouteLines(shared_ptr<MapDisplay> display, std::vector<NodePointer> nodeList);
+
     
     static void setPortrait(bool);
 };

--- a/Common/Code/DefaultVisualization.hpp
+++ b/Common/Code/DefaultVisualization.hpp
@@ -10,8 +10,8 @@
 
 //TODO: move these to a better place
 #define SELECTED_NODE_COLOR_HEX 0x00A8EC
-#define SELECTED_CONNECTION_COLOR_BRIGHT_HEX 0xE0E0E0
-#define SELECTED_CONNECTION_COLOR_DIM_HEX 0x383838
+#define SELECTED_CONNECTION_COLOR_SELF_HEX 0x7F7F7F
+#define SELECTED_CONNECTION_COLOR_OTHER_HEX 0xE0E0E0
 
 //#define UIColorFromRGB(rgbValue) [UIColor colorWithRed:((float)((rgbValue & 0xFF0000) >> 16))/255.0 green:((float)((rgbValue & 0xFF00) >> 8))/255.0 blue:((float)(rgbValue & 0xFF))/255.0 alpha:1.0]
 
@@ -29,9 +29,9 @@ public:
     virtual void updateDisplayForNodes(shared_ptr<DisplayNodes> display, std::vector<NodePointer> nodes);
     virtual void updateDisplayForSelectedNodes(shared_ptr<MapDisplay> display, std::vector<NodePointer> nodes);
     virtual void resetDisplayForSelectedNodes(shared_ptr<MapDisplay> display, std::vector<NodePointer> nodes);
-    virtual void updateLineDisplay(shared_ptr<MapDisplay> display, std::vector<ConnectionPointer>connections);
+    virtual void updateLineDisplay(shared_ptr<MapDisplay> display);
     virtual void updateHighlightRouteLines(shared_ptr<MapDisplay> display, std::vector<NodePointer> nodeList);
-
+    virtual void updateConnectionLines(shared_ptr<MapDisplay> display, NodePointer node, std::vector<ConnectionPointer> connections);
     
     static void setPortrait(bool);
 };

--- a/Common/Code/DefaultVisualization.hpp
+++ b/Common/Code/DefaultVisualization.hpp
@@ -12,6 +12,7 @@
 #define SELECTED_NODE_COLOR_HEX 0x00A8EC
 #define SELECTED_CONNECTION_COLOR_SELF_HEX 0x383838
 #define SELECTED_CONNECTION_COLOR_OTHER_HEX 0xE0E0E0
+#define ROUTE_COLOR 0xffa300
 
 //#define UIColorFromRGB(rgbValue) [UIColor colorWithRed:((float)((rgbValue & 0xFF0000) >> 16))/255.0 green:((float)((rgbValue & 0xFF00) >> 8))/255.0 blue:((float)(rgbValue & 0xFF))/255.0 alpha:1.0]
 

--- a/Common/Code/GlobeVisualization.cpp
+++ b/Common/Code/GlobeVisualization.cpp
@@ -9,6 +9,7 @@
 #include "GlobeVisualization.hpp"
 #include "DisplayLines.hpp"
 #include "MapDisplay.hpp"
+#include "MapUtilities.hpp"
 #include <stdlib.h>
 
 Point3 polarToCartesian(float latitude, float longitude, float radius) {
@@ -59,7 +60,7 @@ float GlobeVisualization::nodeSize(NodePointer node) {
     return 0.005 + 0.2 * powf(node->importance, .90);
 }
 
-void GlobeVisualization::updateLineDisplay(shared_ptr<MapDisplay> display, std::vector<ConnectionPointer>connections) {
+void GlobeVisualization::updateLineDisplay(shared_ptr<MapDisplay> display) {
     
     shared_ptr<DisplayLines> lines(new DisplayLines(20 * 20 + 20 * 20));
     
@@ -145,5 +146,61 @@ void GlobeVisualization::updateHighlightRouteLines(std::shared_ptr<MapDisplay> d
     lines->endUpdate();
     lines->setWidth(5.0);
 
+    display->highlightLines = lines;
+}
+
+void GlobeVisualization::updateConnectionLines(shared_ptr<MapDisplay> display, NodePointer node, std::vector<ConnectionPointer> connections) {
+    int numSubdiv = 30;
+    float radius = length(Vector3(nodePosition(node)));
+
+
+    shared_ptr<DisplayLines> lines(new DisplayLines(connections.size() * numSubdiv));
+    lines->beginUpdate();
+
+    Color selfColor = ColorFromRGB(SELECTED_CONNECTION_COLOR_SELF_HEX);
+    Color otherColor = ColorFromRGB(SELECTED_CONNECTION_COLOR_OTHER_HEX);
+
+    for(unsigned int i = 0; i < connections.size(); i++) {
+        ConnectionPointer connection = connections[i];
+        NodePointer a = connection->first;
+        NodePointer b = connection->second;
+
+        if(node == b) {
+            b = a;
+            a = node;
+        }
+
+        // Draw lines from outside of nodes instead of center
+        Point3 positionA = nodePosition(a);
+        Point3 positionB = nodePosition(b);
+
+        Point3 start = MapUtilities().pointOnSurfaceOfNode(nodeSize(a), positionA, positionB);
+        Point3 end = MapUtilities().pointOnSurfaceOfNode(nodeSize(b), positionB, positionA);
+
+        Point3 lastSubdivPoint = start;
+        Color lastSubdivColor = selfColor;
+
+        for(unsigned int j = 0; j < numSubdiv; j++) {
+            float t = float(j + 1) / float(numSubdiv);
+            Vector3 newSubdivVector = normalize(Vector3(lerp(t, start, end)));
+            Point3 newSubdivPoint = scale(Point3(newSubdivVector), radius);
+            Color newSubdivColor = Color(selfColor.r + ((otherColor.r - selfColor.r) * t), selfColor.g + ((otherColor.g - selfColor.g) * t), selfColor.b + ((otherColor.b - selfColor.b) * t), selfColor.a + ((otherColor.a - selfColor.a) * t));
+            lines->updateLine((i * numSubdiv) + j, lastSubdivPoint, lastSubdivColor, newSubdivPoint, newSubdivColor);
+            lastSubdivPoint = newSubdivPoint;
+            lastSubdivColor = newSubdivColor;
+        }
+
+        /*
+        // The bright side is the current node
+        if(node == a) {
+            lines->updateLine(i, outsideA, brightColor, outsideB, dimColor);
+        }
+        else {
+            lines->updateLine(i, outsideA, dimColor, outsideB, brightColor);
+        }*/
+    }
+
+    lines->endUpdate();
+    lines->setWidth(((connections.size() < 20) ? 2 : 1));
     display->highlightLines = lines;
 }

--- a/Common/Code/GlobeVisualization.cpp
+++ b/Common/Code/GlobeVisualization.cpp
@@ -115,7 +115,7 @@ void GlobeVisualization::updateLineDisplay(shared_ptr<MapDisplay> display) {
     display->visualizationLines = lines;
 }
 
-void GlobeVisualization::updateHighlightRouteLines(std::shared_ptr<MapDisplay> display, std::vector<NodePointer> nodeList) {
+void GlobeVisualization::updateHighlightRouteLines(shared_ptr<MapDisplay> display, std::vector<NodePointer> nodeList) {
     int numSubdiv = 35;
     float radius = length(Vector3(nodePosition(nodeList[0])));
     float maxElevation = 0.0f;//radius * 0.25;

--- a/Common/Code/GlobeVisualization.cpp
+++ b/Common/Code/GlobeVisualization.cpp
@@ -114,3 +114,36 @@ void GlobeVisualization::updateLineDisplay(shared_ptr<MapDisplay> display, std::
     display->visualizationLines = lines;
 }
 
+void GlobeVisualization::updateHighlightRouteLines(std::shared_ptr<MapDisplay> display, std::vector<NodePointer> nodeList) {
+    int numSubdiv = 35;
+    float radius = length(Vector3(nodePosition(nodeList[0])));
+    float maxElevation = 0.0f;//radius * 0.25;
+
+    shared_ptr<DisplayLines> lines(new DisplayLines(static_cast<int>(nodeList.size() - 1) * numSubdiv));
+    lines->beginUpdate();
+    Color lineColor = ColorFromRGB(0xffa300);
+
+    for(unsigned int i = 0; i < nodeList.size() - 1; i++) {
+        NodePointer a = nodeList[i];
+        NodePointer b = nodeList[i+1];
+
+        Point3 start = nodePosition(a);
+        Point3 end = nodePosition(b);
+        Point3 lastSubdivPoint = start;
+        float segmentElevation = fmin(maxElevation * (length(start - end) / radius), maxElevation);
+
+        for(unsigned int j = 0; j < numSubdiv; j++) {
+            float t = float(j + 1) / float(numSubdiv);
+            Vector3 newSubdivVector = normalize(Vector3(lerp(t, start, end)));
+            float elevation = radius + (segmentElevation * (1.414f * sqrt(0.5 - fabs(t - 0.5)) ));
+            Point3 newSubdivPoint = scale(Point3(newSubdivVector), elevation);
+            lines->updateLine((i * numSubdiv) + j, lastSubdivPoint, lineColor, newSubdivPoint, lineColor);
+            lastSubdivPoint = newSubdivPoint;
+        }
+    }
+
+    lines->endUpdate();
+    lines->setWidth(5.0);
+
+    display->highlightLines = lines;
+}

--- a/Common/Code/GlobeVisualization.cpp
+++ b/Common/Code/GlobeVisualization.cpp
@@ -116,13 +116,13 @@ void GlobeVisualization::updateLineDisplay(shared_ptr<MapDisplay> display) {
 }
 
 void GlobeVisualization::updateHighlightRouteLines(shared_ptr<MapDisplay> display, std::vector<NodePointer> nodeList) {
-    int numSubdiv = 35;
+    int numSubdiv = 30;
     float radius = length(Vector3(nodePosition(nodeList[0])));
     float maxElevation = 0.0f;//radius * 0.25;
 
     shared_ptr<DisplayLines> lines(new DisplayLines(static_cast<int>(nodeList.size() - 1) * numSubdiv));
     lines->beginUpdate();
-    Color lineColor = ColorFromRGB(0xffa300);
+    Color lineColor = ColorFromRGB(ROUTE_COLOR);
 
     for(unsigned int i = 0; i < nodeList.size() - 1; i++) {
         NodePointer a = nodeList[i];
@@ -189,15 +189,6 @@ void GlobeVisualization::updateConnectionLines(shared_ptr<MapDisplay> display, N
             lastSubdivPoint = newSubdivPoint;
             lastSubdivColor = newSubdivColor;
         }
-
-        /*
-        // The bright side is the current node
-        if(node == a) {
-            lines->updateLine(i, outsideA, brightColor, outsideB, dimColor);
-        }
-        else {
-            lines->updateLine(i, outsideA, dimColor, outsideB, brightColor);
-        }*/
     }
 
     lines->endUpdate();

--- a/Common/Code/GlobeVisualization.hpp
+++ b/Common/Code/GlobeVisualization.hpp
@@ -21,8 +21,9 @@ public:
 
     virtual std::string name(void) { return "Globe View"; }
     
-    void updateLineDisplay(shared_ptr<MapDisplay> display, std::vector<ConnectionPointer>connections);
+    void updateLineDisplay(shared_ptr<MapDisplay> display);
     void updateHighlightRouteLines(shared_ptr<MapDisplay> display, std::vector<NodePointer> nodeList);
+    void updateConnectionLines(shared_ptr<MapDisplay> display, NodePointer node, std::vector<ConnectionPointer> connections);
 
 };
 

--- a/Common/Code/GlobeVisualization.hpp
+++ b/Common/Code/GlobeVisualization.hpp
@@ -22,6 +22,7 @@ public:
     virtual std::string name(void) { return "Globe View"; }
     
     void updateLineDisplay(shared_ptr<MapDisplay> display, std::vector<ConnectionPointer>connections);
+    void updateHighlightRouteLines(shared_ptr<MapDisplay> display, std::vector<NodePointer> nodeList);
 
 };
 

--- a/Common/Code/MapController.cpp
+++ b/Common/Code/MapController.cpp
@@ -333,7 +333,11 @@ void MapController::highlightRoute(std::vector<NodePointer> nodeList) {
         clearHighlightLines();
         return;
     }
-    
+
+    if(dynamic_cast<GlobeVisualization*>(data->visualization.get())) {
+        highlightRouteOnGlobe(nodeList);
+        return;
+    }
 
     shared_ptr<DisplayLines> lines(new DisplayLines(static_cast<int>(nodeList.size() - 1)));
     lines->beginUpdate();
@@ -363,6 +367,61 @@ void MapController::highlightRoute(std::vector<NodePointer> nodeList) {
     display->nodes->endUpdate();
     selectedNodes->endUpdate();
     
+    display->highlightLines = lines;
+    display->selectedNodes = selectedNodes;
+}
+
+void MapController::highlightRouteOnGlobe(std::vector<NodePointer> nodeList) {
+    if(nodeList.size() <= 1) {
+        clearHighlightLines();
+        return;
+    }
+
+    int numSubdiv = 35;
+    float radius = length(Vector3(data->visualization->nodePosition(nodeList[0])));
+    float maxElevation = 0.0f;//radius * 0.25;
+
+    shared_ptr<DisplayLines> lines(new DisplayLines(static_cast<int>(nodeList.size() - 1) * numSubdiv));
+    lines->beginUpdate();
+    Color lineColor = ColorFromRGB(0xffa300);
+
+    for(unsigned int i = 0; i < nodeList.size() - 1; i++) {
+        NodePointer a = nodeList[i];
+        NodePointer b = nodeList[i+1];
+
+        Point3 start = data->visualization->nodePosition(a);
+        Point3 end = data->visualization->nodePosition(b);
+        Point3 lastSubdivPoint = start;
+        float segmentElevation = fmin(maxElevation * (length(start - end) / radius), maxElevation);
+
+        for(unsigned int j = 0; j < numSubdiv; j++) {
+            float t = float(j + 1) / float(numSubdiv);
+            Vector3 newSubdivVector = normalize(Vector3(lerp(t, start, end)));
+            float elevation = radius + (segmentElevation * (1.414f * sqrt(0.5 - fabs(t - 0.5)) ));
+            Point3 newSubdivPoint = scale(Point3(newSubdivVector), elevation);
+            lines->updateLine((i * numSubdiv) + j, lastSubdivPoint, lineColor, newSubdivPoint, lineColor);
+                                        lastSubdivPoint = newSubdivPoint;
+        }
+    }
+
+    lines->endUpdate();
+    lines->setWidth(5.0);
+
+    shared_ptr<DisplayNodes> selectedNodes(new DisplayNodes(static_cast<int>(nodeList.size())));
+
+    selectedNodes->beginUpdate();
+    display->nodes->beginUpdate();
+
+    for(unsigned int i = 0; i < nodeList.size(); i++) {
+        NodePointer node = nodeList[i];
+        display->nodes->updateNode(node->index, ColorFromRGB(SELECTED_NODE_COLOR_HEX));
+        selectedNodes->updateNode(i, data->visualization->nodePosition(node), data->visualization->nodeSize(node) * 0.8, ColorFromRGB(SELECTED_NODE_COLOR_HEX));
+        highlightedNodes.insert(node->index);
+    }
+
+    display->nodes->endUpdate();
+    selectedNodes->endUpdate();
+
     display->highlightLines = lines;
     display->selectedNodes = selectedNodes;
 }

--- a/Common/Code/MapController.cpp
+++ b/Common/Code/MapController.cpp
@@ -282,6 +282,25 @@ void MapController::highlightConnections(NodePointer node) {
         std::sort(filteredConnections.begin(), filteredConnections.end(), importanceCompareConnections);
         std::random_shuffle(filteredConnections.begin() + NUM_IMPORTANT_CONNECTIONS, filteredConnections.end());
         filteredConnections.resize(NUM_RENDERED_CONNECTIONS);
+
+        for(int i = filteredConnections.size() - 1; i > 0; i--) {
+            for(int j = i-1; j >= 0; j--) {
+                NodePointer a = filteredConnections[i]->first;
+                if(a == node) {
+                    a = filteredConnections[i]->second;
+                }
+
+                NodePointer b = filteredConnections[j]->first;
+                if(b == node) {
+                    b = filteredConnections[j]->second;
+                }
+
+                if(length(data->visualization->nodePosition(a) - data->visualization->nodePosition(b)) < 0.005) {
+                    filteredConnections.erase(filteredConnections.begin() + i);
+                    break;
+                }
+            }
+        }
     }
 
     data->visualization->updateConnectionLines(display, node, filteredConnections);

--- a/Common/Code/MapController.cpp
+++ b/Common/Code/MapController.cpp
@@ -274,46 +274,17 @@ void MapController::highlightConnections(NodePointer node) {
         }
     }
     
-    static const unsigned int NUM_IMPORTANT_CONNECTIONS = 50;
-    static const unsigned int NUM_RENDERED_CONNECTIONS = 100;
+    static const unsigned int NUM_IMPORTANT_CONNECTIONS = 40;
+    static const unsigned int NUM_RENDERED_CONNECTIONS = 60;
     
     if (filteredConnections.size() > NUM_RENDERED_CONNECTIONS) {
         // show a few of the most important ones, then a random selection from the rest
         std::sort(filteredConnections.begin(), filteredConnections.end(), importanceCompareConnections);
         std::random_shuffle(filteredConnections.begin() + NUM_IMPORTANT_CONNECTIONS, filteredConnections.end());
+        filteredConnections.resize(NUM_RENDERED_CONNECTIONS);
     }
-    
-    int renderedConnections = std::min((unsigned int)(filteredConnections.size()), NUM_RENDERED_CONNECTIONS);
-    shared_ptr<DisplayLines> lines(new DisplayLines(renderedConnections));
-    lines->beginUpdate();
-    
-    Color brightColor = ColorFromRGB(SELECTED_CONNECTION_COLOR_BRIGHT_HEX);
-    Color dimColor = ColorFromRGB(SELECTED_CONNECTION_COLOR_DIM_HEX);
 
-    for(unsigned int i = 0; i < renderedConnections; i++) {
-        ConnectionPointer connection = filteredConnections[i];
-        NodePointer a = connection->first;
-        NodePointer b = connection->second;
-        
-        // Draw lines from outside of nodes instead of center
-        Point3 positionA = data->visualization->nodePosition(a);
-        Point3 positionB = data->visualization->nodePosition(b);
-        
-        Point3 outsideA = MapUtilities().pointOnSurfaceOfNode(data->visualization->nodeSize(a), positionA, positionB);
-        Point3 outsideB = MapUtilities().pointOnSurfaceOfNode(data->visualization->nodeSize(b), positionB, positionA);
-
-        // The bright side is the current node
-        if(node == a) {
-            lines->updateLine(i, outsideA, brightColor, outsideB, dimColor);
-        }
-        else {
-            lines->updateLine(i, outsideA, dimColor, outsideB, brightColor);
-        }
-    }
-    
-    lines->endUpdate();
-    lines->setWidth(((filteredConnections.size() < 20) ? 2 : 1));
-    display->highlightLines = lines;
+    data->visualization->updateConnectionLines(display, node, filteredConnections);
 }
 
 void MapController::clearHighlightLines() {
@@ -508,12 +479,12 @@ void MapController::updateDisplay(bool blend) {
     
     if(blend) {
         data->visualization->updateDisplayForNodes(display->targetNodes, data->nodes);
-        data->visualization->updateLineDisplay(display, data->connections);
+        data->visualization->updateLineDisplay(display);
         display->startBlend(1.0f);
     }
     else {
         data->visualization->updateDisplayForNodes(display->nodes, data->nodes);
-        data->visualization->updateLineDisplay(display, data->connections);
+        data->visualization->updateLineDisplay(display);
     }
     
     if(targetNode != INT_MAX) {

--- a/Common/Code/MapController.hpp
+++ b/Common/Code/MapController.hpp
@@ -47,7 +47,8 @@ public:
     void setVisualization(int visualization);
     
 private:
-    
+    void highlightRouteOnGlobe(std::vector<NodePointer> nodeList);
+
     int hoveredNodeIndex;
     std::vector<VisualizationPointer> _visualizations;
 };

--- a/Common/Code/Visualization.hpp
+++ b/Common/Code/Visualization.hpp
@@ -40,9 +40,11 @@ public:
     
     // Update the visualizationLines in the display
     // Note: unlike updateDisplay, this will replace all existing lines
-    virtual void updateLineDisplay(shared_ptr<MapDisplay> display, std::vector<ConnectionPointer>connections) = 0;
+    virtual void updateLineDisplay(shared_ptr<MapDisplay> display) = 0;
 
+    // Update the higlight lines with either route or connections, will also remove existing highligh lines
     virtual void updateHighlightRouteLines(shared_ptr<MapDisplay> display, std::vector<NodePointer> nodeList) = 0;
+    virtual void updateConnectionLines(shared_ptr<MapDisplay> display, NodePointer node, std::vector<ConnectionPointer> connections) = 0;
 };
 
 typedef shared_ptr<Visualization> VisualizationPointer;

--- a/Common/Code/Visualization.hpp
+++ b/Common/Code/Visualization.hpp
@@ -41,6 +41,8 @@ public:
     // Update the visualizationLines in the display
     // Note: unlike updateDisplay, this will replace all existing lines
     virtual void updateLineDisplay(shared_ptr<MapDisplay> display, std::vector<ConnectionPointer>connections) = 0;
+
+    virtual void updateHighlightRouteLines(shared_ptr<MapDisplay> display, std::vector<NodePointer> nodeList) = 0;
 };
 
 typedef shared_ptr<Visualization> VisualizationPointer;


### PR DESCRIPTION
When in globe visualization, make connections and traceroute into arcs following the surface of the globe rather than straight lines cutting through it. 

Should work fine on Android, but has not been tested (particularly from a performance standpoint. @ssawchenko, could you maybe try building (and checking performance, this does render a lot more lines than before) on Android?