### PR TITLE
Update app to build on Xcode 9

### DIFF
--- a/External Code/SCPinions/SCPacketUtility/SCPacketDeclarations.h
+++ b/External Code/SCPinions/SCPacketUtility/SCPacketDeclarations.h
@@ -50,17 +50,18 @@ struct IPHeader {
 
 typedef struct IPHeader IPHeader;
 
-check_compile_time(sizeof(IPHeader) == 20);
-check_compile_time(offsetof(IPHeader, versionAndHeaderLength) == 0);
-check_compile_time(offsetof(IPHeader, differentiatedServices) == 1);
-check_compile_time(offsetof(IPHeader, totalLength) == 2);
-check_compile_time(offsetof(IPHeader, identification) == 4);
-check_compile_time(offsetof(IPHeader, flagsAndFragmentOffset) == 6);
-check_compile_time(offsetof(IPHeader, timeToLive) == 8);
-check_compile_time(offsetof(IPHeader, protocol) == 9);
-check_compile_time(offsetof(IPHeader, headerChecksum) == 10);
-check_compile_time(offsetof(IPHeader, sourceAddress) == 12);
-check_compile_time(offsetof(IPHeader, destinationAddress) == 16);
+
+__Check_Compile_Time(sizeof(IPHeader) == 20);
+__Check_Compile_Time(offsetof(IPHeader, versionAndHeaderLength) == 0);
+__Check_Compile_Time(offsetof(IPHeader, differentiatedServices) == 1);
+__Check_Compile_Time(offsetof(IPHeader, totalLength) == 2);
+__Check_Compile_Time(offsetof(IPHeader, identification) == 4);
+__Check_Compile_Time(offsetof(IPHeader, flagsAndFragmentOffset) == 6);
+__Check_Compile_Time(offsetof(IPHeader, timeToLive) == 8);
+__Check_Compile_Time(offsetof(IPHeader, protocol) == 9);
+__Check_Compile_Time(offsetof(IPHeader, headerChecksum) == 10);
+__Check_Compile_Time(offsetof(IPHeader, sourceAddress) == 12);
+__Check_Compile_Time(offsetof(IPHeader, destinationAddress) == 16);
 
 // ICMP:
 
@@ -84,12 +85,12 @@ enum {
     kICMPTimeExceeded = 11
 };
 
-check_compile_time(sizeof(ICMPHeader) == 8);
-check_compile_time(offsetof(ICMPHeader, type) == 0);
-check_compile_time(offsetof(ICMPHeader, code) == 1);
-check_compile_time(offsetof(ICMPHeader, checksum) == 2);
-check_compile_time(offsetof(ICMPHeader, identifier) == 4);
-check_compile_time(offsetof(ICMPHeader, sequenceNumber) == 6);
+__Check_Compile_Time(sizeof(ICMPHeader) == 8);
+__Check_Compile_Time(offsetof(ICMPHeader, type) == 0);
+__Check_Compile_Time(offsetof(ICMPHeader, code) == 1);
+__Check_Compile_Time(offsetof(ICMPHeader, checksum) == 2);
+__Check_Compile_Time(offsetof(ICMPHeader, identifier) == 4);
+__Check_Compile_Time(offsetof(ICMPHeader, sequenceNumber) == 6);
 
 struct ICMPErrorPacket {
     // IP Header
@@ -141,11 +142,11 @@ struct UDPHeader {
 
 typedef struct UDPHeader UDPHeader;
 
-check_compile_time(sizeof(UDPHeader) == 8);
-check_compile_time(offsetof(UDPHeader, sport) == 0);
-check_compile_time(offsetof(UDPHeader, dport) == 2);
-check_compile_time(offsetof(UDPHeader, length) == 4);
-check_compile_time(offsetof(UDPHeader,checksum) == 6);
+__Check_Compile_Time(sizeof(UDPHeader) == 8);
+__Check_Compile_Time(offsetof(UDPHeader, sport) == 0);
+__Check_Compile_Time(offsetof(UDPHeader, dport) == 2);
+__Check_Compile_Time(offsetof(UDPHeader, length) == 4);
+__Check_Compile_Time(offsetof(UDPHeader,checksum) == 6);
 
 
 #endif


### PR DESCRIPTION
Some non-standard compile time asserts were using old names that have been changed.