### PR TITLE
Switch iOS to use physical pixels in MapController interface

### DIFF
--- a/Common/Code/MapDisplay.cpp
+++ b/Common/Code/MapDisplay.cpp
@@ -49,18 +49,8 @@ void MapDisplay::bindDefaultNodeUniforms(shared_ptr<Program> program) {
     glUniformMatrix4fv(program->uniformForName("projectionMatrix"), 1, 0, reinterpret_cast<float*>(&p));
     glUniform1f(program->uniformForName("maxSize"), maxPointSize); // Largest size to render a node. May be too large for slow devices
     
-    // On iOS display size is in logical pixels, so we need to include display scale as well
-    // On Android the display size is in physical pixels, so we don't apply the display scale here
-    // We still use the display scale on logicial elements (like the max point size above,
-    // or the line width), so that we wont have (for example) point size capping out early and making
-    // things much smaller on high density android devices
-#ifdef ANDROID
     glUniform1f(program->uniformForName("screenWidth"), camera->displayWidth());
     glUniform1f(program->uniformForName("screenHeight"), camera->displayHeight());
-#else
-    glUniform1f(program->uniformForName("screenWidth"), _displayScale * camera->displayWidth());
-    glUniform1f(program->uniformForName("screenHeight"), _displayScale * camera->displayHeight());
-#endif
 }
 
 void MapDisplay::draw(void)
@@ -90,13 +80,7 @@ void MapDisplay::draw(void)
     
 #ifndef BUILD_MAC
     // Mac does viewport trickery for the high-res screenshots, don't want to get up in it's areas
-    // on iOS display size is in logical pixels, so we need to include display scale as well
-    // On android the display size is in physical pixels, so we don't apply the display scale here
-#ifdef ANDROID
     glViewport(0, 0, camera->displayWidth(), camera->displayHeight());
-#else
-    glViewport(0, 0, camera->displayWidth() * _displayScale, camera->displayHeight() * _displayScale);
-#endif
 #endif
     
 

--- a/iOS/ViewController.m
+++ b/iOS/ViewController.m
@@ -304,17 +304,24 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
 
 - (void)update
 {
-    self.controller.displaySize = CGSizeMake(self.view.bounds.size.width, self.view.bounds.size.height);
     [self.controller setAllowIdleAnimation:[self shouldDoIdleAnimation]];
     [self.controller update:[NSDate timeIntervalSinceReferenceDate]];
 }
 
 - (void)glkView:(GLKView *)view drawInRect:(CGRect)rect
 {
+    self.controller.displaySize = CGSizeMake(view.drawableWidth, view.drawableHeight);
     [self.controller draw];
 }
 
 #pragma mark - Touch and GestureRecognizer handlers
+
+- (CGPoint)toDisplayPoint:(CGPoint)point {
+    GLKView* view = (GLKView*)self.view;
+    point.x = (point.x / view.bounds.size.width) * view.drawableWidth;
+    point.y = (point.y / view.bounds.size.height) * view.drawableHeight;
+    return point;
+}
 
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
     [super touchesBegan:touches withEvent:event];
@@ -322,9 +329,10 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
     if (touch.view == self.buttonContainerView) {
         return;
     }
+
     self.isHandlingLongPress = NO;
 
-    [self.controller handleTouchDownAtPoint:[touch locationInView:self.view]];
+    [self.controller handleTouchDownAtPoint:[self toDisplayPoint:[touch locationInView:self.view]]];
 }
 
 -(void)handleTap:(UITapGestureRecognizer*)gestureRecognizer {
@@ -357,7 +365,8 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
     if(gesture.state == UIGestureRecognizerStateBegan || gesture.state == UIGestureRecognizerStateChanged) {
         if ((!self.lastIntersectionDate || fabs([self.lastIntersectionDate timeIntervalSinceNow]) > 0.01)) {
             self.isHandlingLongPress = YES;
-            int i = [self.controller indexForNodeAtPoint:[gesture locationInView:self.view]];
+
+            int i = [self.controller indexForNodeAtPoint:[self toDisplayPoint: [gesture locationInView:self.view]]];
             self.lastIntersectionDate = [NSDate date];
             if (i != NSNotFound && [self.controller isWithinMaxNodeIndex:i]) {
 
@@ -1004,7 +1013,7 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
     CGRect displayRect;
     
     if (![HelperMethods deviceIsiPad]) {
-        displayRect = CGRectMake(160, self.controller.displaySize.height-self.nodeInformationViewController.preferredContentSize.height, 1, 1);
+        displayRect = CGRectMake(160, self.view.bounds.size.height-self.nodeInformationViewController.preferredContentSize.height, 1, 1);
     } else {                
         displayRect = CGRectMake([[UIScreen mainScreen] bounds].size.width/2, [[UIScreen mainScreen] bounds].size.height/2, 1, 1);
     }


### PR DESCRIPTION
To handle the fact that we get the real frame buffer size (1920x1080) on the plus size devices when rendering with OpenGL.