### PR TITLE
Add safe area insets to the size of the node info popup

### DIFF
--- a/iOS/NodeInformationViewController.h
+++ b/iOS/NodeInformationViewController.h
@@ -19,7 +19,7 @@
 @interface NodeInformationViewController : UIViewController
 
 
-- (id)initWithNode:(NodeWrapper*)node isCurrentNode:(BOOL)isCurrent;
+- (id)initWithNode:(NodeWrapper*)node isCurrentNode:(BOOL)isCurrent parent:(UIView*)parent;
 - (void)tracerouteDone;
 
 @property (strong, nonatomic) UILabel* topLabel;

--- a/iOS/NodeInformationViewController.m
+++ b/iOS/NodeInformationViewController.m
@@ -114,7 +114,12 @@
         
         height += verticalPad; //bottom margin
 
-        self.safeAreaPadding = parent.safeAreaInsets.bottom;
+        if (@available(iOS 11.0, *)) {
+            self.safeAreaPadding = parent.safeAreaInsets.bottom;
+        } else {
+            self.safeAreaPadding = 0;
+        }
+
         height += self.safeAreaPadding;
 
         self.contentHeight = height;

--- a/iOS/NodeInformationViewController.m
+++ b/iOS/NodeInformationViewController.m
@@ -39,6 +39,8 @@
 
 @property (nonatomic, assign) float contentHeight;
 
+@property (nonatomic, assign) CGFloat safeAreaPadding;
+
 @end
 
 @implementation NodeInformationViewController
@@ -49,7 +51,7 @@
     }
 }
 
-- (id)initWithNode:(NodeWrapper*)node isCurrentNode:(BOOL)isCurrent
+- (id)initWithNode:(NodeWrapper*)node isCurrentNode:(BOOL)isCurrent parent:(UIView*)parent
 {
     self = [super init];
     if (self) {
@@ -111,6 +113,10 @@
         }
         
         height += verticalPad; //bottom margin
+
+        self.safeAreaPadding = parent.safeAreaInsets.bottom;
+        height += self.safeAreaPadding;
+
         self.contentHeight = height;
 
         float width = [HelperMethods deviceIsiPad] ? 443 : [[UIScreen mainScreen] bounds].size.width;
@@ -189,7 +195,7 @@
     // traceroute button
     if (!self.isDisplayingCurrentNode) {
         self.tracerouteButton = [UIButton buttonWithType:UIButtonTypeCustom];
-        float tracerouteButtonY = self.preferredContentSize.height - TRACEROUTE_BUTTON_HEIGHT - verticalPad + 10;
+        float tracerouteButtonY = self.preferredContentSize.height - TRACEROUTE_BUTTON_HEIGHT - verticalPad - self.safeAreaPadding + 10;
         self.tracerouteButton.frame = CGRectMake(20, tracerouteButtonY, self.scrollView.bounds.size.width - 40, TRACEROUTE_BUTTON_HEIGHT);
         self.tracerouteButton.titleLabel.font = [UIFont fontWithName:FONT_NAME_REGULAR size:20];
         [self.tracerouteButton setTitle:NSLocalizedString(@"Perform Traceroute", nil) forState:UIControlStateNormal];

--- a/iOS/ViewController.m
+++ b/iOS/ViewController.m
@@ -831,7 +831,7 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
         NodeWrapper* node = [self.controller nodeAtIndex:self.controller.targetNode];
         
         //careful, the local assignment first is necessary, because the property is a weak reference
-        NodeInformationViewController* controller = [[NodeInformationViewController alloc] initWithNode:node isCurrentNode:isSelectingCurrentNode];
+        NodeInformationViewController* controller = [[NodeInformationViewController alloc] initWithNode:node isCurrentNode:isSelectingCurrentNode parent: self.view];
         self.nodeInformationViewController = controller;
         self.nodeInformationViewController.delegate = self;
 


### PR DESCRIPTION
So the traceroute button isn’t under the home indicator on the iPhone X