### PR TITLE
Supress timeline rotation

### DIFF
--- a/iOS/ViewController.m
+++ b/iOS/ViewController.m
@@ -729,7 +729,7 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
         [weakSelf.controller setVisualization:vis];
     };
     
-    [self forceResetView];
+    [self resetView];
 }
 
 -(IBAction)infoButtonPressed:(id)sender {
@@ -991,7 +991,7 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
         }
     };
     
-    [self forceResetView];
+    [self resetView];
 }
 
 //deselect node and reset zoom/rotate. If you set the afterViewReset callback, it will be called when this finishes.
@@ -1001,6 +1001,14 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
     [self dismissNodeInfoPopover];
     [self.controller deselectCurrentNode];
     [self resetVisualization];
+
+    if(self.arEnabled && self.afterViewReset) {
+        // In AR mode we don't actually change the rotation on a view reset, so if there is a post reset callback,
+        // call it now
+        // TODO: should really find a better way to handle this
+        self.afterViewReset();
+        self.afterViewReset = nil;
+    }
 }
 
 // Full reset of UI state, including rotating back to default. Used in cases where we do need a full reset (like switching visualizations)

--- a/iOS/ViewController.m
+++ b/iOS/ViewController.m
@@ -1089,7 +1089,7 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
 #pragma mark - NodeInfo delegate
 
 - (void)dismissNodeInfoPopover {
-    self.repositionButton.hidden = self.arMode != ARModeViewing;
+    self.repositionButton.hidden = (self.arMode != ARModeViewing) || (self.timelineSlider.hidden == NO);
 
     [self.tracer stop];
     self.tracer = nil;


### PR DESCRIPTION
Fixes #532.

Works by firing off the afterViewReset callback immediately in cases where the view reset won't actually happen due to being in AR mode. 

Not super happy with how this works, but I'm not confidant that there's a better way to do it without rethinking how the camera animation stuff works, which is probably to big a thing to take on just for this one minor cleanup. Open to suggestions though.