### PR TITLE
Improved AR timeline node popover positioning

### DIFF
--- a/iOS/ViewController.m
+++ b/iOS/ViewController.m
@@ -902,15 +902,19 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
         [self.nodeInformationPopover dismissPopoverAnimated:NO];
         NodeTooltipViewController* content = [[NodeTooltipViewController alloc] initWithNode:node];
         self.nodeInformationPopover = [[WEPopoverController alloc] initWithContentViewController:content];
+
+        if (self.arEnabled) {
+            WEPopoverContainerViewProperties *properties = [WEPopoverContainerViewProperties defaultContainerViewProperties];
+            properties.downArrowImageName = nil;
+            self.nodeInformationPopover.containerViewProperties = properties;
+        }
         
         if(simulated) {
             content.text = @"Simulated data";
         }
         
         self.nodeInformationPopover.passthroughViews = @[self.view];
-        CGPoint center = [self.controller getCoordinatesForNodeAtIndex:self.controller.targetNode];
-        
-        [self.nodeInformationPopover presentPopoverFromRect:CGRectMake(center.x, center.y, 1, 1) inView:self.view permittedArrowDirections:UIPopoverArrowDirectionDown animated:NO];
+        [self.nodeInformationPopover presentPopoverFromRect:[self displayRectForTimelineNodeInfoPopover] inView:self.view permittedArrowDirections:UIPopoverArrowDirectionDown animated:NO];
     }
     else {
         //check if node is the current node
@@ -1110,6 +1114,17 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
     }
     
     return displayRect;
+}
+
+- (CGRect)displayRectForTimelineNodeInfoPopover {
+    if (self.arEnabled) {
+        CGRect timelinePopoverFrame = self.timelinePopover.view.frame;
+        return CGRectMake([[UIScreen mainScreen] bounds].size.width/2, timelinePopoverFrame.origin.y - self.nodeInformationPopover.view.height, 1, 1);
+    } else {
+        CGPoint center = [self.controller getCoordinatesForNodeAtIndex:self.controller.targetNode];
+        CGRect displayRect = CGRectMake(center.x, center.y, 1, 1);
+        return displayRect;
+    }
 }
 
 - (void)resizeNodeInfoPopover {

--- a/iOS/ViewController.m
+++ b/iOS/ViewController.m
@@ -1126,8 +1126,9 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
 
 - (CGRect)displayRectForTimelineNodeInfoPopover {
     if (self.arEnabled) {
-        CGRect timelinePopoverFrame = self.timelinePopover.view.frame;
-        return CGRectMake([[UIScreen mainScreen] bounds].size.width/2, timelinePopoverFrame.origin.y - self.nodeInformationPopover.view.height, 1, 1);
+        CGRect sliderFrame = self.timelineSlider.frame;
+        NSInteger padding = 150;
+        return CGRectMake([[UIScreen mainScreen] bounds].size.width/2, sliderFrame.origin.y - padding, 1, 1);
     } else {
         CGPoint center = [self.controller getCoordinatesForNodeAtIndex:self.controller.targetNode];
         CGRect displayRect = CGRectMake(center.x, center.y, 1, 1);


### PR DESCRIPTION
Fixes #535 

I tried to do some relative positioning based on the height of the timeline blurb that we show but it looked bad when scrubbing the slider (the blurb height varies from 1-3 lines in my testing). This just offsets the node info popover a fixed amount from the slider.

![img_5b74c9de9d00-1](https://user-images.githubusercontent.com/430436/36816504-cffdec7a-1c92-11e8-8a29-77a828325b2b.jpeg)
