### PR TITLE
Simplify help tooltip positioning

### DIFF
--- a/iOS/ViewController.m
+++ b/iOS/ViewController.m
@@ -1223,17 +1223,17 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
 
         UIButton *buttonForHelp = orderOfMenuButtons[helpLocation];
         CGPoint globalCoordinates = [buttonForHelp convertPoint:buttonForHelp.origin toView:self.view];
-        float xPosition = globalCoordinates.x;
+        CGFloat xPosition = globalCoordinates.x;
         NSInteger xPadding = 0;
+        _helpPopBackImage.image = [UIImage imageNamed:@"callout_left.png"];
 
-        if ([HelperMethods deviceIsiPad]) {
-            xPadding = -18;
-        } else if (buttonForHelp == _timelineButton) { // iphone and right button, dont want to clip on small screens
+        CGRect newRect = [self.view convertRect:buttonForHelp.frame fromView:buttonForHelp];
+        NSLog(@"newRect %@", NSStringFromCGRect(newRect));
+
+        if (xPosition + self.helpPopView.frame.size.width > CGRectGetMaxX(self.view.frame)) {
+            // Readjust callout location if popover would clip
             xPadding = -112;
             _helpPopBackImage.image = [UIImage imageNamed:@"callout_right.png"];
-        } else {
-            xPadding = 0;
-            _helpPopBackImage.image = [UIImage imageNamed:@"callout_left.png"];
         }
 
         self.helpPopViewPosition.constant = xPosition + xPadding;

--- a/iOS/ViewController.m
+++ b/iOS/ViewController.m
@@ -1227,9 +1227,6 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
         NSInteger xPadding = 0;
         _helpPopBackImage.image = [UIImage imageNamed:@"callout_left.png"];
 
-        CGRect newRect = [self.view convertRect:buttonForHelp.frame fromView:buttonForHelp];
-        NSLog(@"newRect %@", NSStringFromCGRect(newRect));
-
         if (xPosition + self.helpPopView.frame.size.width > CGRectGetMaxX(self.view.frame)) {
             // Readjust callout location if popover would clip
             xPadding = -112;


### PR DESCRIPTION
Fixes #513 

Only use the right side callout if tooltip will clip (happens on non-AR capable 6 and 5s). Removes manual adjustment for iPad tooltips.