### PR TITLE
AR node selection and sizing

### DIFF
--- a/Common/Code/Camera.cpp
+++ b/Common/Code/Camera.cpp
@@ -76,7 +76,7 @@ void Camera::update(TimeInterval currentTime) {
 
     // Half size of nodes and change seletion colour when camera is overriden, implying we are in AR mode
     // TODO: should have better way of distributing this info
-    DefaultVisualization::setNodeScale(overrideCamera ? 0.75 : 1.0);
+    DefaultVisualization::setNodeScale(overrideCamera ? 0.33 : 1.0);
     DefaultVisualization::setSelectedNodeColour(overrideCamera ? ColorFromRGB(0xFFA500) : ColorFromRGB(SELECTED_NODE_COLOR_HEX));
 
     if (overrideCamera) {

--- a/Common/Code/Camera.cpp
+++ b/Common/Code/Camera.cpp
@@ -19,7 +19,6 @@ void cameraMoveFinishedCallback(void);
 void cameraResetFinishedCallback(void);
 
 Camera::Camera() :
-
     _mode(MODE_UNKNOWN),
     _displayWidth(0.0f),
     _displayHeight(0.0f),
@@ -56,9 +55,6 @@ Camera::Camera() :
     _panVelocity.y = 0.0f;
 }
 
-static const float NEAR_PLANE = 0.05f;
-static const float FAR_PLANE = 100.0f;
-
 void Camera::update(TimeInterval currentTime) {
     TimeInterval delta = currentTime - _updateTime;
     _updateTime = currentTime;
@@ -73,11 +69,6 @@ void Camera::update(TimeInterval currentTime) {
     handleAnimatedTranslateY(delta);
     
     float aspect = fabsf(_displayWidth / _displayHeight);
-
-    // Half size of nodes and change seletion colour when camera is overriden, implying we are in AR mode
-    // TODO: should have better way of distributing this info
-    DefaultVisualization::setNodeScale(overrideCamera ? 0.33 : 1.0);
-    DefaultVisualization::setSelectedNodeColour(overrideCamera ? ColorFromRGB(0xFFA500) : ColorFromRGB(SELECTED_NODE_COLOR_HEX));
 
     if (overrideCamera) {
         float scaleInMetres = 1.0;

--- a/Common/Code/Camera.hpp
+++ b/Common/Code/Camera.hpp
@@ -20,6 +20,9 @@ struct Target {
     Target():vector(0, 0, 0), zoom(0.0f), maxZoom(0.0f) {}
 };
 
+const float NEAR_PLANE = 0.05f;
+const float FAR_PLANE = 100.0f;
+
 /**
  the opengl camera for the view.
  has nice functions for targeting, animated zoom, rotation, etc.

--- a/Common/Code/MapController.cpp
+++ b/Common/Code/MapController.cpp
@@ -413,7 +413,7 @@ int MapController::indexForNodeAtPoint(Vector2 pointInView) {
                     
 //                    printf("intersected node %i, delta: %f\n", i, delta);
                     Vector4 transformedNodePosition = display->camera->currentModelView() * Vector4(nodePosition.getX(), nodePosition.getY(), nodePosition.getZ(), 1);
-                    if ((delta > maxDelta) && (transformedNodePosition.getZ() < -0.05)) {
+                    if ((delta > maxDelta) && (transformedNodePosition.getZ() < -NEAR_PLANE)) {
                         maxDelta = delta;
                         foundI = i;
                     }

--- a/Common/Code/MapController.cpp
+++ b/Common/Code/MapController.cpp
@@ -413,7 +413,7 @@ int MapController::indexForNodeAtPoint(Vector2 pointInView) {
                     
 //                    printf("intersected node %i, delta: %f\n", i, delta);
                     Vector4 transformedNodePosition = display->camera->currentModelView() * Vector4(nodePosition.getX(), nodePosition.getY(), nodePosition.getZ(), 1);
-                    if ((delta > maxDelta) && (transformedNodePosition.getZ() < -0.1)) {
+                    if ((delta > maxDelta) && (transformedNodePosition.getZ() < -0.05)) {
                         maxDelta = delta;
                         foundI = i;
                     }

--- a/iOS/MapControllerWrapper.h
+++ b/iOS/MapControllerWrapper.h
@@ -57,8 +57,14 @@
 
 - (NSArray*)visualizationNames;
 - (void)setVisualization:(int)vis;
+- (void)updateVisualization;
 
 - (void)overrideCameraTransform:(matrix_float4x4)transform projection:(matrix_float4x4)projection modelPos:(GLKVector3)modelPos;
 - (void)clearCameraOverride;
+
+- (void)enableAR:(BOOL)enable;
+
+- (float)nearPlane;
+- (float)farPlane;
 
 @end

--- a/iOS/MapControllerWrapper.mm
+++ b/iOS/MapControllerWrapper.mm
@@ -135,6 +135,14 @@ Matrix4 Matrix4FromGLKMatrix4(GLKMatrix4 mat) {
     _controller->display->camera->resetIdleTimer();
 }
 
+- (float)nearPlane {
+    return NEAR_PLANE;
+}
+
+- (float)farPlane {
+    return FAR_PLANE;
+}
+
 #pragma mark - Camera: View Manipulation
 
 - (void)resetZoomAndRotationAnimatedForOrientation:(BOOL)isPortraitMode{
@@ -191,6 +199,15 @@ Matrix4 Matrix4FromGLKMatrix4(GLKMatrix4 mat) {
 
 - (void)stopMomentumZoom{
     _controller->display->camera->stopMomentumZoom();
+}
+
+
+#pragma mark - AR
+
+- (void)enableAR:(BOOL)enable {
+    DefaultVisualization::setNodeScale(enable ? 0.5 : 1.0);
+    DefaultVisualization::setSelectedNodeColour(enable ? ColorFromRGB(0xFFA500) : ColorFromRGB(SELECTED_NODE_COLOR_HEX));
+    _controller->updateDisplay(false);
 }
 
 - (void)overrideCameraTransform:(matrix_float4x4)transform projection:(matrix_float4x4)projection modelPos:(GLKVector3)modelPos {

--- a/iOS/RootVC.swift
+++ b/iOS/RootVC.swift
@@ -30,7 +30,7 @@ private class CameraDelegate: NSObject, ARSessionDelegate {
         let view = renderer.view as! GLKView
         let size = CGSize(width: view.drawableWidth, height: view.drawableHeight)
 
-        renderer.overrideCamera(frame.camera.viewMatrix(for: orientation), projection: frame.camera.projectionMatrix(for: orientation, viewportSize: size, zNear: 0.05, zFar: 100), modelPos:modelPos)
+        renderer.overrideCamera(frame.camera.viewMatrix(for: orientation), projection: frame.camera.projectionMatrix(for: orientation, viewportSize: size, zNear: CGFloat(renderer.nearPlane()), zFar: CGFloat(renderer.farPlane())), modelPos:modelPos)
 
         let cameraOrientation: CGImagePropertyOrientation = UIDevice.current.userInterfaceIdiom == .phone ? .right : (orientation == .landscapeRight ? .up : .down)
         cameraImage.image = UIImage(ciImage: CIImage(cvPixelBuffer: frame.capturedImage).oriented(cameraOrientation))

--- a/iOS/ViewController.h
+++ b/iOS/ViewController.h
@@ -22,4 +22,7 @@ typedef NS_ENUM(NSInteger, ARMode) {
 - (void)moreAboutCogeco;
 - (void)overrideCamera:(matrix_float4x4)transform projection:(matrix_float4x4)projection modelPos:(GLKVector3)modelPos;
 - (void)setARMode:(ARMode)mode;
+- (float)nearPlane;
+- (float)farPlane;
+
 @end

--- a/iOS/ViewController.m
+++ b/iOS/ViewController.m
@@ -356,12 +356,10 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
     self.arEnabled = mode != ARModeDisabled;
     self.arMode = mode;
 
-    if(!wasEnabled && self.arEnabled) {
-        [self forceResetView];
-    }
-
-    if(wasEnabled && !self.arEnabled) {
+    if(wasEnabled ^ self.arEnabled) {
         [self.controller clearCameraOverride];
+        [self forceResetView];
+        [self.controller enableAR:self.arEnabled];
     }
 
     self.renderEnabled = mode != ARModeSearching;
@@ -382,6 +380,14 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
 
 -(IBAction)repositionButtonPressed:(id)sender {
     [((AppDelegate*)([UIApplication sharedApplication].delegate)).rootVC startPlacement];
+}
+
+- (float)nearPlane {
+    return [self.controller nearPlane];
+}
+
+- (float)farPlane {
+    return [self.controller farPlane];
 }
 
 #pragma mark - Touch and GestureRecognizer handlers

--- a/iOS/ViewController.m
+++ b/iOS/ViewController.m
@@ -356,7 +356,7 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
     self.arEnabled = mode != ARModeDisabled;
     self.arMode = mode;
 
-    if(wasEnabled ^ self.arEnabled) {
+    if(wasEnabled != self.arEnabled) {
         [self.controller clearCameraOverride];
         [self forceResetView];
         [self.controller enableAR:self.arEnabled];


### PR DESCRIPTION
This fixes #525 and fixes #544.

Nodes that were between the near clip plane and z = -0.1we visible but not selectable, so as you moved closer to small nodes, you'd stop being able to select them (any node within 10cm of the camera).

This also fixes an issue where the difference in node size between AR and non-AR wasn't always picked up, and sets the node scale for AR to the desired value of 0.5