### PR TITLE
Skip `handleTouchDownAtPoint` when in AR search or placement mode

### DIFF
--- a/iOS/ViewController.m
+++ b/iOS/ViewController.m
@@ -402,6 +402,11 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
 
     self.isHandlingLongPress = NO;
 
+    if (self.arMode == ARModeSearching || self.arMode == ARModePlacing) {
+        NSLog(@"Skipping touch handling due to current AR mode: %zd", self.arMode);
+        return;
+    }
+
     [self.controller handleTouchDownAtPoint:[self toDisplayPoint:[touch locationInView:self.view]]];
 }
 


### PR DESCRIPTION
Fixes #543 

The view controller also has a `UITapGestureRecognizer` handler that I didn't modify. I'm not sure if we should do the same thing there or not.

```
-(void)handleTap:(UITapGestureRecognizer*)gestureRecognizer {
    [self.controller resetIdleTimer];
    [self dismissNodeInfoPopover];
    [self helpPopCheckOrMenuSelected:nil];

    if (![self.controller selectHoveredNode]) { //couldn't select node
        if(self.controller.targetNode != INT_MAX) {
            [self.controller deselectCurrentNode];
            [self resetVisualization];
        }
    }	
}
```
