### PR TITLE
Support iPad rotation

### DIFF
--- a/iOS/CreditsViewController.swift
+++ b/iOS/CreditsViewController.swift
@@ -188,7 +188,7 @@ public class CreditsViewController: UIViewController, UIWebViewDelegate {
     }
 
     public override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        return UIDevice.current.userInterfaceIdiom == .pad ? .landscape : .portrait
+        return UIDevice.current.userInterfaceIdiom == .pad ? .all : .portrait
     }
 
     override public func viewWillAppear(_ animated: Bool) {

--- a/iOS/InternetMap-Info.plist
+++ b/iOS/InternetMap-Info.plist
@@ -66,6 +66,8 @@
 	<array>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>

--- a/iOS/RootVC.swift
+++ b/iOS/RootVC.swift
@@ -32,7 +32,18 @@ private class CameraDelegate: NSObject, ARSessionDelegate {
 
         renderer.overrideCamera(frame.camera.viewMatrix(for: orientation), projection: frame.camera.projectionMatrix(for: orientation, viewportSize: size, zNear: CGFloat(renderer.nearPlane()), zFar: CGFloat(renderer.farPlane())), modelPos:modelPos)
 
-        let cameraOrientation: CGImagePropertyOrientation = UIDevice.current.userInterfaceIdiom == .phone ? .right : (orientation == .landscapeRight ? .up : .down)
+        let cameraOrientation: CGImagePropertyOrientation
+        if UIDevice.current.userInterfaceIdiom == .phone {
+            cameraOrientation = .right
+        } else {
+            switch orientation {
+            case .landscapeRight: cameraOrientation = .up
+            case .landscapeLeft: cameraOrientation = .down
+            case .portrait: cameraOrientation = .right
+            case .portraitUpsideDown: cameraOrientation = .left
+            default: cameraOrientation = .up
+            }
+        }
         cameraImage.image = UIImage(ciImage: CIImage(cvPixelBuffer: frame.capturedImage).oriented(cameraOrientation))
     }
 }
@@ -78,7 +89,9 @@ public class RootVC: UIViewController {
         guard ARConfiguration.isSupported else { return NSLog("Attempted to set up AR session for unsupported device.") }
         let image = UIImageView()
         image.frame = view.frame
+        image.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         image.alpha = 0.5
+        image.contentMode = .scaleAspectFill
         view.addSubview(image)
         view.sendSubview(toBack: image)
         imageView = image

--- a/iOS/ViewController.m
+++ b/iOS/ViewController.m
@@ -281,11 +281,6 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
     self.repositionButton.layer.borderColor = UI_BLUE_COLOR.CGColor;
 }
 
--(BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {
-    // Not sure if this is ever invoked anymore
-    return [HelperMethods deviceIsiPad] ? UIInterfaceOrientationIsLandscape(interfaceOrientation) : UIInterfaceOrientationIsPortrait(interfaceOrientation);
-}
-
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
     bool shownFirstUse = [[NSUserDefaults standardUserDefaults] boolForKey:@"shownFirstUse"];

--- a/iOS/ViewController.m
+++ b/iOS/ViewController.m
@@ -282,7 +282,7 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
 }
 
 -(BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {
-    
+    // Not sure if this is ever invoked anymore
     return [HelperMethods deviceIsiPad] ? UIInterfaceOrientationIsLandscape(interfaceOrientation) : UIInterfaceOrientationIsPortrait(interfaceOrientation);
 }
 
@@ -981,6 +981,9 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
         self.nodeInformationPopover.delegate = self;
         self.nodeInformationPopover.passthroughViews = @[self.view];
         UIPopoverArrowDirection dir = UIPopoverArrowDirectionLeft;
+        if ([HelperMethods deviceIsiPad] && UIInterfaceOrientationIsPortrait([UIApplication sharedApplication].statusBarOrientation)) {
+            dir = UIPopoverArrowDirectionUp;
+        }
 
         if (![HelperMethods deviceIsiPad] || self.arEnabled) {
             WEPopoverContainerViewProperties* prop = [WEPopoverContainerViewProperties defaultContainerViewProperties];
@@ -1448,6 +1451,12 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
     [self resizeNodeInfoPopover];
 
     [self displayHops:hops withDestNode:[self.controller nodeAtIndex:self.controller.targetNode]];
+}
+
+#pragma mark - Rotation and transitions
+
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+    [self dismissNodeInfoPopover];
 }
 
 @end


### PR DESCRIPTION
Fixes #509 

I spent some time trying to avoid the harsh rotation so that we could let the camera view rotate naturally but I didn't make any good progress on it. I couldn't even find a great sample ARKit app that handles rotation nicely - if you happen to know of one, send it my way and I can see what approach they used.

This adds "normal" rotation support. The popovers get out of whack if they're visible during a rotation, so I've set them to dismiss with `viewWillTransitionToSize`.

One line that isn't strictly necessary but I think fixes a bug that could cause the AR view to be stretched is `image.contentMode = .scaleAspectFill`. Let me know if you think that's ok.