### PR TITLE
Catch a few more cases of places we need to convert between logical and physical pixels

### DIFF
--- a/iOS/MapControllerWrapper.h
+++ b/iOS/MapControllerWrapper.h
@@ -15,7 +15,8 @@
 
 
 @property (nonatomic) unsigned int targetNode;
-@property (nonatomic) CGSize displaySize;
+@property (nonatomic) CGSize logicalDisplaySize;
+@property (nonatomic) CGSize physicalDisplaySize;
 @property (nonatomic, readonly) float currentZoom;
 @property (nonatomic, strong) NSString* lastSearchIP;
 

--- a/iOS/MapControllerWrapper.mm
+++ b/iOS/MapControllerWrapper.mm
@@ -91,11 +91,11 @@ Matrix4 Matrix4FromGLKMatrix4(GLKMatrix4 mat) {
     _controller->targetNode = targetNode;
 }
 
-- (CGSize)displaySize {
+- (CGSize)physicalDisplaySize {
     return CGSizeMake(_controller->display->camera->displayWidth(), _controller->display->camera->displayHeight());
 }
 
-- (void)setDisplaySize:(CGSize)displaySize {
+- (void)setPhysicalDisplaySize:(CGSize)displaySize {
     _controller->display->camera->setDisplaySize(displaySize.width, displaySize.height);
 }
 
@@ -121,6 +121,13 @@ Matrix4 Matrix4FromGLKMatrix4(GLKMatrix4 mat) {
     _controller->hoverNode(index);
 }
 
+-(CGPoint)logicalToPhysical:(CGPoint)point {
+    return CGPointMake((point.x / self.logicalDisplaySize.width) * self.physicalDisplaySize.width, (point.y / self.logicalDisplaySize.height) * self.physicalDisplaySize.height);
+}
+
+-(CGPoint)physicalToLogical:(CGPoint)point {
+    return CGPointMake((point.x / self.physicalDisplaySize.width) * self.logicalDisplaySize.width, (point.y / self.physicalDisplaySize.height) * self.logicalDisplaySize.height);
+}
 #pragma mark - Camera: Misc
 
 - (void)update:(NSTimeInterval)now{
@@ -261,6 +268,7 @@ Matrix4 Matrix4FromGLKMatrix4(GLKMatrix4 mat) {
 #pragma mark - Controller: Event handling
 
 - (void)handleTouchDownAtPoint:(CGPoint)point{
+    point = [self logicalToPhysical:point];
     _controller->handleTouchDownAtPoint(Vector2(point.x, point.y));
 }
 
@@ -279,12 +287,13 @@ Matrix4 Matrix4FromGLKMatrix4(GLKMatrix4 mat) {
 }
 
 - (int)indexForNodeAtPoint:(CGPoint)pointInView{
+    pointInView = [self logicalToPhysical:pointInView];
     return _controller->indexForNodeAtPoint(Vector2(pointInView.x, pointInView.y));
 }
 
 -(CGPoint)getCoordinatesForNodeAtIndex:(int)index{
     Vector2 vec = _controller->getCoordinatesForNodeAtIndex(index);
-    return CGPointMake(vec.x, vec.y);
+    return [self physicalToLogical:CGPointMake(vec.x, vec.y)];
 }
 
 - (void)updateTargetForIndex:(int)index{

--- a/iOS/ViewController.m
+++ b/iOS/ViewController.m
@@ -323,14 +323,14 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
 
 - (void)update
 {
-    self.controller.displaySize = CGSizeMake(self.view.bounds.size.width, self.view.bounds.size.height);
+    self.controller.logicalDisplaySize = CGSizeMake(self.view.bounds.size.width, self.view.bounds.size.height);
     [self.controller setAllowIdleAnimation:[self shouldDoIdleAnimation]];
     [self.controller update:[NSDate timeIntervalSinceReferenceDate]];
 }
 
 - (void)glkView:(GLKView *)view drawInRect:(CGRect)rect
 {
-    self.controller.displaySize = CGSizeMake(view.drawableWidth, view.drawableHeight);
+    self.controller.physicalDisplaySize = CGSizeMake(view.drawableWidth, view.drawableHeight);
 
     if(self.renderEnabled) {
         [self.controller draw];
@@ -392,13 +392,6 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
 
 #pragma mark - Touch and GestureRecognizer handlers
 
-- (CGPoint)toDisplayPoint:(CGPoint)point {
-    GLKView* view = (GLKView*)self.view;
-    point.x = (point.x / view.bounds.size.width) * view.drawableWidth;
-    point.y = (point.y / view.bounds.size.height) * view.drawableHeight;
-    return point;
-}
-
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
     [super touchesBegan:touches withEvent:event];
     UITouch* touch = [touches anyObject];
@@ -413,7 +406,7 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
         return;
     }
 
-    [self.controller handleTouchDownAtPoint:[self toDisplayPoint:[touch locationInView:self.view]]];
+    [self.controller handleTouchDownAtPoint:[touch locationInView:self.view]];
 }
 
 -(void)handleTap:(UITapGestureRecognizer*)gestureRecognizer {
@@ -447,7 +440,7 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
         if ((!self.lastIntersectionDate || fabs([self.lastIntersectionDate timeIntervalSinceNow]) > 0.01)) {
             self.isHandlingLongPress = YES;
 
-            int i = [self.controller indexForNodeAtPoint:[self toDisplayPoint: [gesture locationInView:self.view]]];
+            int i = [self.controller indexForNodeAtPoint:[gesture locationInView:self.view]];
             self.lastIntersectionDate = [NSDate date];
             if (i != NSNotFound && [self.controller isWithinMaxNodeIndex:i]) {
 


### PR DESCRIPTION
There are some cases we need to cover between UIView pixel co-ordiantes and framebuffer coordinates to get things to look right on the Plus size devices, since they have a mismatch in those sizes. I'd fixed some of those already, but I found one that was still broken (the hover selection, where you drag your finger over the view and it shows the small node popups and then selects the current one when you release, which I had totally forgotten about).

This change fixes the map APIs involved in that, and also moves the conversion between those spaces into the MapControllerWrapper, which should make it a little less error prone in the future because you now: 
- Can't screw it up just by using one of the existing functions on that class wrong, you would have to actually add a new function to it that was wrong.
- It now tracks those two sizes separately, rather than conflating them in some weird ways, where the "displaySize" variable meant different things at different points in the frame update.