### PR TITLE
Consolidate node info popover arrow direction logic

### DIFF
--- a/iOS/ViewController.m
+++ b/iOS/ViewController.m
@@ -945,7 +945,8 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
         }
         
         self.nodeInformationPopover.passthroughViews = @[self.view];
-        [self.nodeInformationPopover presentPopoverFromRect:[self displayRectForTimelineNodeInfoPopover] inView:self.view permittedArrowDirections:UIPopoverArrowDirectionDown animated:NO];
+        UIPopoverArrowDirection dir = [self popoverArrowDirectionForNodeInformationPopover];
+        [self.nodeInformationPopover presentPopoverFromRect:[self displayRectForTimelineNodeInfoPopover] inView:self.view permittedArrowDirections:dir animated:NO];
     }
     else {
         //check if node is the current node
@@ -968,18 +969,14 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
         self.nodeInformationPopover = [[WEPopoverController alloc] initWithContentViewController:self.nodeInformationViewController];
         self.nodeInformationPopover.delegate = self;
         self.nodeInformationPopover.passthroughViews = @[self.view];
-        UIPopoverArrowDirection dir = UIPopoverArrowDirectionLeft;
-        if ([HelperMethods deviceIsiPad] && UIInterfaceOrientationIsPortrait([UIApplication sharedApplication].statusBarOrientation)) {
-            dir = UIPopoverArrowDirectionUp;
-        }
 
         if (![HelperMethods deviceIsiPad] || self.arEnabled) {
             WEPopoverContainerViewProperties* prop = [WEPopoverContainerViewProperties defaultContainerViewProperties];
             prop.upArrowImageName = nil;
             self.nodeInformationPopover.containerViewProperties = prop;
-            dir = UIPopoverArrowDirectionUp;
         }
-            
+
+        UIPopoverArrowDirection dir = [self popoverArrowDirectionForNodeInformationPopover];
         [self.nodeInformationPopover presentPopoverFromRect:[self displayRectForNodeInfoPopover] inView:self.view permittedArrowDirections:dir animated:YES];
 
         self.repositionButton.hidden = true;
@@ -1170,9 +1167,21 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
     }
 }
 
+- (UIPopoverArrowDirection)popoverArrowDirectionForNodeInformationPopover {
+    if (!self.timelineSlider.hidden) {
+        return UIPopoverArrowDirectionDown;
+    }
+
+    if ([HelperMethods deviceIsiPad] && UIInterfaceOrientationIsLandscape([UIApplication sharedApplication].statusBarOrientation)) {
+        return UIPopoverArrowDirectionLeft;
+    }
+
+    return UIPopoverArrowDirectionUp;
+}
+
 - (void)resizeNodeInfoPopover {
     self.nodeInformationPopover.popoverContentSize = CGSizeZero;
-    UIPopoverArrowDirection dir = ([HelperMethods deviceIsiPad] && !self.arEnabled) ? UIPopoverArrowDirectionLeft : UIPopoverArrowDirectionUp;
+    UIPopoverArrowDirection dir = [self popoverArrowDirectionForNodeInformationPopover];
     [self.nodeInformationPopover repositionPopoverFromRect:[self displayRectForNodeInfoPopover] inView:self.view permittedArrowDirections:dir animated:YES];
 }
 


### PR DESCRIPTION
For #552 

This fixes the arrow direction problem in iPad portrait traceroute. There is still a small animation glitch with the popover when the traceroute results expand the popover but I can't figure out what the heck is causing it. It seems to be related to the `preferredContentSize` calculation in `NodeInformationViewController.tracerouteDone` but I don't really understand what's causing the weird animation results in portrait.

Maybe give it a try and let me know if I should keep looking at it for this or if we should just file it and move on.