### PR TITLE
Mark tooltips as shown if the corresponding menu button was activated

### DIFF
--- a/iOS/ViewController.m
+++ b/iOS/ViewController.m
@@ -1262,7 +1262,7 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
 
 -(void) helpPopCheckOrMenuSelected:(UIButton*)menuButton {
     
-    NSMutableString *shownMenusPopsString = [[NSUserDefaults standardUserDefaults] objectForKey:@"helpPopMenusShownDefault"];
+    NSString *shownMenusPopsString = [[NSUserDefaults standardUserDefaults] objectForKey:@"helpPopMenusShownDefault"];
     NSRange range = [shownMenusPopsString rangeOfString:@"0"];
     if (range.location == NSNotFound) return; // all help pops have been shown
     
@@ -1309,10 +1309,9 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
             }
             currentLocation++;
         }
-        if (currentLocation != helpLocation) return;
-        
+
         // the menu with the tooltip has been viewed, mark as 1
-        shownMenusPopsString = (NSMutableString *)[shownMenusPopsString stringByReplacingCharactersInRange:NSMakeRange(helpLocation, 1) withString:@"1"];
+        shownMenusPopsString = [shownMenusPopsString stringByReplacingCharactersInRange:NSMakeRange(currentLocation, 1) withString:@"1"];
         [[NSUserDefaults standardUserDefaults] setObject:shownMenusPopsString forKey:@"helpPopMenusShownDefault"];
         [[NSUserDefaults standardUserDefaults] synchronize];
     }


### PR DESCRIPTION
Fixes #553

The previous tooltip logic would only update the `helpPopMenusShownDefault` setting if the user had tapped on the menu item while the tooltip was being shown. (`currentLocation != helpLocation`). From what I can tell, this has been the behaviour since the feature was added.

I also fixed some incorrect `NSMutableString` casting.