### PR TITLE
Various bug fixes

### DIFF
--- a/iOS/Main.storyboard
+++ b/iOS/Main.storyboard
@@ -187,8 +187,8 @@
                                         <state key="disabled" title="AR">
                                             <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         </state>
-                                        <state key="selected" title="AR" image="info-selected.png">
-                                            <color key="titleColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                        <state key="selected" title="AR">
+                                            <color key="titleColor" red="0.18823529411764706" green="0.65098039215686276" blue="0.86274509803921573" alpha="1" colorSpace="calibratedRGB"/>
                                         </state>
                                         <state key="highlighted" title="AR">
                                             <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>

--- a/iOS/Main.storyboard
+++ b/iOS/Main.storyboard
@@ -264,21 +264,14 @@
                                     <constraint firstAttribute="height" constant="55" id="rUO-mf-G1A"/>
                                 </constraints>
                             </view>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EDv-r7-fjC">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="AR Searching Text" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EDv-r7-fjC">
                                 <rect key="frame" x="107" y="343" width="200" height="70"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="70" id="RwG-KK-B5x"/>
                                     <constraint firstAttribute="width" constant="200" id="a9e-I1-x1k"/>
                                 </constraints>
-                                <attributedString key="attributedText">
-                                    <fragment content="Move the camera across a flat surface to place the map.">
-                                        <attributes>
-                                            <color key="NSColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                            <font key="NSFont" size="20" name="NexaLight"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" lineHeightMultiple="1.1499999999999999" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                </attributedString>
+                                <fontDescription key="fontDescription" name="NexaLight" family="Nexa Light" pointSize="20"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3p7-hg-SfJ">

--- a/iOS/RootVC.swift
+++ b/iOS/RootVC.swift
@@ -80,7 +80,10 @@ public class RootVC: UIViewController {
         if mode == .disabled {
             if AVCaptureDevice.authorizationStatus(forMediaType: AVMediaTypeVideo) == .notDetermined {
                 AVCaptureDevice.requestAccess(forMediaType: AVMediaTypeVideo) { granted in
-                    self.mode = .searching
+                    DispatchQueue.main.async {
+                        self.mode = .searching
+
+                    }
                 }
             }
             else {

--- a/iOS/RootVC.swift
+++ b/iOS/RootVC.swift
@@ -78,7 +78,14 @@ public class RootVC: UIViewController {
 
     func toggleAR() {
         if mode == .disabled {
-            mode = .searching
+            if AVCaptureDevice.authorizationStatus(forMediaType: AVMediaTypeVideo) == .notDetermined {
+                AVCaptureDevice.requestAccess(forMediaType: AVMediaTypeVideo) { granted in
+                    self.mode = .searching
+                }
+            }
+            else {
+                self.mode = .searching
+            }
         }
         else {
             mode = .disabled

--- a/iOS/ViewController.m
+++ b/iOS/ViewController.m
@@ -352,6 +352,9 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
     self.arMode = mode;
 
     if(wasEnabled != self.arEnabled) {
+        if(self.arEnabled) {
+            [self checkCameraAuthorization];
+        }
         [self.controller clearCameraOverride];
         [self forceResetView];
         [self.controller enableAR:self.arEnabled];
@@ -383,6 +386,27 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
 
 - (float)farPlane {
     return [self.controller farPlane];
+}
+
+-(void)checkCameraAuthorization {
+    AVAuthorizationStatus auth = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
+
+    NSString* text = @"Move the camera across a flat surface to place the map";
+
+    if(auth != AVAuthorizationStatusAuthorized) {
+        text = @"Please allow camera access for Internet Map in Settings";
+    }
+
+    NSMutableAttributedString* attrString = [[NSMutableAttributedString alloc] initWithString:text];
+    NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle defaultParagraphStyle] mutableCopy];
+    NSRange range = NSMakeRange(0, text.length);
+
+    [paragraphStyle setLineHeightMultiple:1.15];
+    [paragraphStyle setAlignment:NSTextAlignmentCenter];
+    [attrString addAttribute:NSFontAttributeName value:[UIFont fontWithName:@"NexaLight" size:20] range:range];
+    [attrString addAttribute:NSParagraphStyleAttributeName value:paragraphStyle range:range];
+
+    self.searchingText.attributedText = attrString;
 }
 
 #pragma mark - Touch and GestureRecognizer handlers

--- a/iOS/ViewController.m
+++ b/iOS/ViewController.m
@@ -338,6 +338,8 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
     }
 
     [((AppDelegate*)([UIApplication sharedApplication].delegate)).rootVC toggleAR];
+
+    self.arButton.selected = self.arEnabled;
 }
 
 - (void)overrideCamera:(matrix_float4x4)transform projection:(matrix_float4x4)projection modelPos:(GLKVector3)modelPos {

--- a/iOS/ViewController.m
+++ b/iOS/ViewController.m
@@ -790,7 +790,7 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
             WEPopoverContainerViewProperties *prop = [WEPopoverContainerViewProperties defaultContainerViewProperties];
             prop.upArrowImageName = nil;
             self.infoPopover.containerViewProperties = prop;
-            [self.visualizationSelectionPopover setPopoverContentSize:tableforPopover.preferredContentSize];
+            [self.infoPopover setPopoverContentSize:tableforPopover.preferredContentSize];
         } else {
             [self.infoPopover setPopoverContentSize:CGSizeMake(340, 220)];
         }

--- a/iOS/ViewController.m
+++ b/iOS/ViewController.m
@@ -333,6 +333,10 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
 #pragma mark - AR
 
 -(IBAction)arButtonPressed:(id)sender {
+    if (self.timelineButton.selected) {
+        [self leaveTimelineMode];
+    }
+
     [((AppDelegate*)([UIApplication sharedApplication].delegate)).rootVC toggleAR];
 }
 


### PR DESCRIPTION
Lost of small bug fixes here, so just wrapped them up in one PR rather than having a whole bunch of small ones.

This should fix all of #562, #563, #564, #565.

I didn't fully test the fix for #564, because granting permissions persists across deleting and re-installing the app, and the only way to get the initial prompt back is a full privacy reset (https://useyourloaf.com/blog/reset-location-and-privacy-permissions/), which I don't really want to do on my main phone, which is all I have handy. @apike If you are in the office today, could you verify that it does the correct thing on initial startup (for both allow and deny) on a test device?