### PR TITLE
Guard against invalid target node in traceroute timeout

### DIFF
--- a/iOS/ViewController.m
+++ b/iOS/ViewController.m
@@ -1470,7 +1470,9 @@ BOOL UIGestureRecognizerStateIsActive(UIGestureRecognizerState state) {
     [self.nodeInformationViewController tracerouteDone];
     [self resizeNodeInfoPopover];
 
-    [self displayHops:hops withDestNode:[self.controller nodeAtIndex:self.controller.targetNode]];
+    if (self.controller.targetNode != INT_MAX) {
+        [self displayHops:hops withDestNode:[self.controller nodeAtIndex:self.controller.targetNode]];
+    }
 }
 
 #pragma mark - Rotation and transitions


### PR DESCRIPTION
Should prevent the crash reported in https://dashboard.buddybuild.com/apps/582ba3b8a9c52a010058e3e9/crashreport/8285cbe9b56952cb6a9805ec85c4b8d1

I wasn't able to reproduce the crash so there might be a more serious underlying bug related to how the target node is being set/reset in some case. This should at least prevent the app from crashing if it gets in to that state again.