### PR TITLE
Change the ping detail labels/values and other minor UI tweaks.

### DIFF
--- a/iOS/NodeInformationViewController.m
+++ b/iOS/NodeInformationViewController.m
@@ -288,7 +288,6 @@ typedef NS_ENUM(NSInteger, MOINodeAction) {
 
         self.tracerouteContainerView.alpha = 0;
         self.tracerouteContainerView.hidden = NO;
-        self.topLabel.text = [NSString stringWithFormat:@"To %@", self.topLabel.text];
 
         if (![HelperMethods deviceIsiPad]) {
             self.scrollView.frame = CGRectMake(0, self.scrollView.frame.origin.y, self.scrollView.frame.size.width, self.scrollView.frame.size.height+250);
@@ -313,15 +312,17 @@ typedef NS_ENUM(NSInteger, MOINodeAction) {
         //tell delegate to perform actual action
         switch (action) {
             case MOINodeActionPing:
-                self.box1.textLabel.text = NSLocalizedString(@"Sent", nil);
-                self.box2.textLabel.text = NSLocalizedString(@"Received", nil);
-                self.box3.textLabel.text = NSLocalizedString(@"Lost", nil);
+                self.topLabel.text = [NSString stringWithFormat:@"Pinging %@", self.topLabel.text];
+                self.box1.textLabel.text = NSLocalizedString(@"Average", nil);
+                self.box2.textLabel.text = NSLocalizedString(@"Best", nil);
+                self.box3.textLabel.text = NSLocalizedString(@"Received", nil);
                 self.detailsLabel.text = NSLocalizedString(@"Details of Ping", nil);
                 if ([self.delegate respondsToSelector:@selector(nodeInformationViewControllerDidTriggerPingAction:)]) {
                     [self.delegate nodeInformationViewControllerDidTriggerPingAction:self];
                 }
                 break;
             case MOINodeActionTraceroute:
+                self.topLabel.text = [NSString stringWithFormat:@"To %@", self.topLabel.text];
                 self.tracerouteTimer = [NSTimer scheduledTimerWithTimeInterval:0.001 target:self selector:@selector(tracerouteTimerFired) userInfo:nil repeats:YES];
                 self.box1.textLabel.text = NSLocalizedString(@"IP Hops", nil);
                 self.box2.textLabel.text = NSLocalizedString(@"ASN Hops", nil);

--- a/iOS/PingLocationsViewController.swift
+++ b/iOS/PingLocationsViewController.swift
@@ -31,12 +31,13 @@ class PingLocationsViewController: UIViewController {
         tableView.backgroundColor = .clear
         tableView.dataSource = self
         tableView.delegate = self
-        tableView.alwaysBounceVertical = false
+        tableView.separatorColor = .lightGray;
+        tableView.separatorInset = UIEdgeInsets(top: 0, left: 15, bottom: 0, right: 15)
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: "Cell")
         view.addSubview(tableView)
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.leftAnchor.constraint(equalTo: view.leftAnchor).isActive = true
-        tableView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+        tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor).isActive = true
         tableView.rightAnchor.constraint(equalTo: view.rightAnchor).isActive = true
         tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
 


### PR DESCRIPTION
For #603 

This updates the ping details UI to closer match the latest mocks. It also allows the ping locations list to bounce vertically and changes the separator color and insets.

![simulator screen shot - iphone x - 2019-02-27 at 16 18 31](https://user-images.githubusercontent.com/430436/53532385-93807a00-3aab-11e9-8136-a44a1b02b57c.png)
